### PR TITLE
drivers: add basic PIC initialization

### DIFF
--- a/drivers/pic.c
+++ b/drivers/pic.c
@@ -1,0 +1,30 @@
+#include <ktf.h>
+#include <lib.h>
+#include <drivers/pic.h>
+
+static inline void pic_outb(io_port_t port, unsigned char value) {
+    outb(port, value);
+    io_delay();
+}
+
+void init_pic(void) {
+    /* Cascade mode initialization sequence */
+    pic_outb(PIC1_PORT_CMD, PIC_ICW1_INIT | PIC_ICW1_ICW4);
+    pic_outb(PIC2_PORT_CMD, PIC_ICW1_INIT | PIC_ICW1_ICW4);
+
+    /* Remap PICs interrupt vectors */
+    pic_outb(PIC1_PORT_DATA, PIC_IRQ0_OFFSET);
+    pic_outb(PIC2_PORT_DATA, PIC_IRQ8_OFFSET);
+
+    /* Set PIC1 and PIC2 cascade IRQ */
+    outb(PIC1_PORT_DATA, PIC_CASCADE_PIC1_IRQ);
+    outb(PIC2_PORT_DATA, PIC_CASCADE_PIC2_IRQ);
+
+    /* PIC mode: 80x86, Automatic EOI */
+    outb(PIC1_PORT_DATA, PIC_ICW4_8086 | PIC_ICW4_AUTO);
+    outb(PIC2_PORT_DATA, PIC_ICW4_8086 | PIC_ICW4_AUTO);
+
+    /* Mask the 8259A PICs by setting all IMR bits */
+    outb(PIC1_PORT_DATA, 0xFF);
+    outb(PIC2_PORT_DATA, 0xFF);
+}

--- a/include/drivers/pic.h
+++ b/include/drivers/pic.h
@@ -1,0 +1,35 @@
+#ifndef KTF_DRV_PIC_H
+#define KTF_DRV_PIC_H
+
+#include <ktf.h>
+
+#define PIC1_PORT_CMD 0x20
+#define PIC2_PORT_CMD 0xa0
+#define PIC1_PORT_DATA (PIC1_PORT_CMD + 1)
+#define PIC2_PORT_DATA (PIC2_PORT_CMD + 1)
+
+#define PIC_EOI 0x20 /* End-of-interrupt command code */
+
+#define PIC_ICW1_ICW4        0x01
+#define PIC_ICW1_SINGLE      0x02 /* Single (cascade) mode */
+#define PIC_ICW1_INTERVAL4   0x04 /* Call address interval 4 (8) */
+#define PIC_ICW1_LEVEL       0x08 /* Level triggered (edge) mode */
+#define PIC_ICW1_INIT        0x10
+
+#define PIC_ICW4_8086        0x01 /* 8086/88 (MCS-80/85) mode */
+#define PIC_ICW4_AUTO        0x02 /* Auto (normal) EOI */
+#define PIC_ICW4_BUF_PIC2    0x08 /* Buffered mode PIC2 */
+#define PIC_ICW4_BUF_PIC1    0x0C /* Buffered mode PIC1 */
+#define PIC_ICW4_SFNM        0x10 /* Special fully nested mode */
+
+#define PIC_CASCADE_PIC2_IRQ 0x02
+#define PIC_CASCADE_PIC1_IRQ 0x04
+
+#define PIC_IRQ0_OFFSET      0x20
+#define PIC_IRQ8_OFFSET      0x28
+
+/* External declarations */
+
+extern void init_pic(void);
+
+#endif /* KTF_DRV_PIC_H */

--- a/setup.c
+++ b/setup.c
@@ -31,6 +31,7 @@
 #include <smp/smp.h>
 
 #include <drivers/serial.h>
+#include <drivers/pic.h>
 
 bool opt_debug;
 
@@ -69,6 +70,12 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic, multiboot_inf
 
     /* Initialize console early */
     init_console();
+
+    /* Initialize Programmable Interrupt Controller */
+    init_pic();
+
+    /* PIC is initialized - enable local interrupts */
+    sti();
 
     if (multiboot_magic == MULTIBOOT_BOOTLOADER_MAGIC) {
         /* Indentity mapping is still on, so fill in multiboot structures */


### PR DESCRIPTION
Initialize PIC1 and PIC2 8259A controllers to a cascade and 80x86 mode
with automatic EOI.  Remap default interrupt vectors to offset 0x20
for PIC1 and 0x28 for PIC2.  Mask all interrupt vectors by default on
both PIC1 and PIC2.

After PICs are initialized, remapped and disabled, enable local
interrupts.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
