### PR TITLE
Run QEMU examples without sudo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,15 @@ export ROOT
 
 ifeq ($(OS),Windows_NT)
 SYSTEM := WIN
-SUDO := 
 else
 UNAME := $(shell uname -s)
 
 ifeq ($(UNAME),Linux)
 SYSTEM := LINUX
-SUDO := sudo
 endif
 
 ifeq ($(UNAME),Darwin)
 SYSTEM := MACOS
-SUDO := 
 endif
 endif
 
@@ -94,24 +91,24 @@ iso: all
 .PHONY: boot
 boot: all
 	@echo "QEMU START"
-	@ $(SUDO) qemu-system-x86_64 -cdrom $(ISO_FILE) $(QEMU_PARAMS)
+	@qemu-system-x86_64 -cdrom $(ISO_FILE) $(QEMU_PARAMS)
 
 .PHONY: boot_debug
 boot_debug: all iso
-	$(SUDO) qemu-system-x86_64 -cdrom $(ISO_FILE) $(QEMU_PARAMS) $(QEMU_PARAMS_DEBUG)
+	qemu-system-x86_64 -cdrom $(ISO_FILE) $(QEMU_PARAMS) $(QEMU_PARAMS_DEBUG)
 
 .PHONY: run
 run: all
-	$(SUDO) "$$QEMU_PATH"/qemu-system-x86_64 -kernel $(TARGET) $(QEMU_PARAMS) $(QEMU_PARAMS_KERNEL)
+	qemu-system-x86_64 -kernel $(TARGET) $(QEMU_PARAMS) $(QEMU_PARAMS_KERNEL)
 
 .PHONY: debug
 debug: all
-	$(SUDO) "$$QEMU_PATH"/qemu-system-x86_64 -kernel $(TARGET) $(QEMU_PARAMS) $(QEMU_PARAMS_KERNEL) $(QEMU_PARAMS_DEBUG)
+	qemu-system-x86_64 -kernel $(TARGET) $(QEMU_PARAMS) $(QEMU_PARAMS_KERNEL) $(QEMU_PARAMS_DEBUG)
 
 .PHONY: gdb
 gdb: debug
 	gdb $(TARGET) -ex 'target remote :1234' -ex 'b _start' -ex 'c'
-	$(SUDO) killall -9 qemu-system-x86_64
+	killall -9 qemu-system-x86_64
 
 define all_sources
 	find $(ROOT) -name "*.[hcsS]"


### PR DESCRIPTION
Running QEMU should be possible as regular user and we should ideally not be
shipping anything that requires users to execute as root.

While we're at it, remove usage of the environment variable QEMU_PATH as it
wasn't use consequentially anyway.

Signed-off-by: Bjoern Doebel <bjoern.doebel@gmail.com>

Closes #26 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
