### PR TITLE
slab allocator: added very simple slab allocator

### DIFF
--- a/include/errno.h
+++ b/include/errno.h
@@ -1,0 +1,127 @@
+#ifndef _KTF_ERRNO_H
+#define _KTF_ERRNO_H
+
+#define    ESUCCESS        0    /*0 is success*/
+#define    EPERM           1    /* Operation not permitted */
+#define    ENOENT          2    /* No such file or directory */
+#define    ESRCH           3    /* No such process */
+#define    EINTR           4    /* Interrupted system call */
+#define    EIO             5    /* I/O error */
+#define    ENXIO           6    /* No such device or address */
+#define    E2BIG           7    /* Arg list too long */
+#define    ENOEXEC         8    /* Exec format error */
+#define    EBADF           9    /* Bad file number */
+#define    ECHILD          10    /* No child processes */
+#define    EAGAIN          11    /* Try again */
+#define    ENOMEM          12    /* Out of memory */
+#define    EACCES          13    /* Permission denied */
+#define    EFAULT          14    /* Bad address */
+#define    ENOTBLK         15    /* Block device required */
+#define    EBUSY           16    /* Device or resource busy */
+#define    EEXIST          17    /* File exists */
+#define    EXDEV           18    /* Cross-device link */
+#define    ENODEV          19    /* No such device */
+#define    ENOTDIR         20    /* Not a directory */
+#define    EISDIR          21    /* Is a directory */
+#define    EINVAL          22    /* Invalid argument */
+#define    ENFILE          23    /* File table overflow */
+#define    EMFILE          24    /* Too many open files */
+#define    ENOTTY          25    /* Not a typewriter */
+#define    ETXTBSY         26    /* Text file busy */
+#define    EFBIG           27    /* File too large */
+#define    ENOSPC          28    /* No space left on device */
+#define    ESPIPE          29    /* Illegal seek */
+#define    EROFS           30    /* Read-only file system */
+#define    EMLINK          31    /* Too many links */
+#define    EPIPE           32    /* Broken pipe */
+#define    EDOM            33    /* Math argument out of domain of func */
+#define    ERANGE          34    /* Math result not representable */
+#define    EDEADLK         35    /* Resource deadlock would occur */
+#define    ENAMETOOLONG    36    /* File name too long */
+#define    ENOLCK          37    /* No record locks available */
+#define    ENOSYS          38    /* Function not implemented */
+#define    ENOTEMPTY       39    /* Directory not empty */
+#define    ELOOP           40    /* Too many symbolic links encountered */
+#define    EWOULDBLOCK     41    /* Operation would block */
+#define    ENOMSG          42    /* No message of desired type */
+#define    EIDRM           43    /* Identifier removed */
+#define    ECHRNG          44    /* Channel number out of range */
+#define    EL2NSYNC        45    /* Level 2 not synchronized */
+#define    EL3HLT          46    /* Level 3 halted */
+#define    EL3RST          47    /* Level 3 reset */
+#define    ELNRNG          48    /* Link number out of range */
+#define    EUNATCH         49    /* Protocol driver not attached */
+#define    ENOCSI          50    /* No CSI structure available */
+#define    EL2HLT          51    /* Level 2 halted */
+#define    EBADE           52    /* Invalid exchange */
+#define    EBADR           53    /* Invalid request descriptor */
+#define    EXFULL          54    /* Exchange full */
+#define    ENOANO          55    /* No anode */
+#define    EBADRQC         56    /* Invalid request code */
+#define    EBADSLT         57    /* Invalid slot */
+#define    EDEADLOCK       58    /* File locking deadlock error */
+#define    EBFONT          59    /* Bad font file format */
+#define    ENOSTR          60    /* Device not a stream */
+#define    ENODATA         61    /* No data available */
+#define    ETIME           62    /* Timer expired */
+#define    ENOSR           63    /* Out of streams resources */
+#define    ENONET          64    /* Machine is not on the network */
+#define    ENOPKG          65    /* Package not installed */
+#define    EREMOTE         66    /* Object is remote */
+#define    ENOLINK         67    /* Link has been severed */
+#define    EADV            68    /* Advertise error */
+#define    ESRMNT          69    /* Srmount error */
+#define    ECOMM           70    /* Communication error on send */
+#define    EPROTO          71    /* Protocol error */
+#define    EMULTIHOP       72    /* Multihop attempted */
+#define    EDOTDOT         73    /* RFS specific error */
+#define    EBADMSG         74    /* Not a data message */
+#define    EOVERFLOW       75    /* Value too large for defined data type */
+#define    ENOTUNIQ        76    /* Name not unique on network */
+#define    EBADFD          77    /* File descriptor in bad state */
+#define    EREMCHG         78    /* Remote address changed */
+#define    ELIBACC         79    /* Can not access a needed shared library */
+#define    ELIBBAD         80    /* Accessing a corrupted shared library */
+#define    ELIBSCN         81    /* .lib section in a.out corrupted */
+#define    ELIBMAX         82    /* Attempting to link in too many shared libraries */
+#define    ELIBEXEC        83    /* Cannot exec a shared library directly */
+#define    EILSEQ          84    /* Illegal byte sequence */
+#define    ERESTART        85    /* Interrupted system call should be restarted */
+#define    ESTRPIPE        86    /* Streams pipe error */
+#define    EUSERS          87    /* Too many users */
+#define    ENOTSOCK        88    /* Socket operation on non-socket */
+#define    EDESTADDRREQ    89    /* Destination address required */
+#define    EMSGSIZE        90    /* Message too long */
+#define    EPROTOTYPE      91    /* Protocol wrong type for socket */
+#define    ENOPROTOOPT     92    /* Protocol not available */
+#define    EPROTONOSUPPORT 93    /* Protocol not supported */
+#define    ESOCKTNOSUPPORT 94    /* Socket type not supported */
+#define    EOPNOTSUPP      95    /* Operation not supported on transport endpoint */
+#define    EPFNOSUPPORT    96    /* Protocol family not supported */
+#define    EAFNOSUPPORT    97    /* Address family not supported by protocol */
+#define    EADDRINUSE      98    /* Address already in use */
+#define    EADDRNOTAVAIL   99    /* Cannot assign requested address */
+#define    ENETDOWN        100    /* Network is down */
+#define    ENETUNREACH     101    /* Network is unreachable */
+#define    ENETRESET       102    /* Network dropped connection because of reset */
+#define    ECONNABORTED    103    /* Software caused connection abort */
+#define    ECONNRESET      104    /* Connection reset by peer */
+#define    ENOBUFS         105    /* No buffer space available */
+#define    EISCONN         106    /* Transport endpoint is already connected */
+#define    ENOTCONN        107    /* Transport endpoint is not connected */
+#define    ESHUTDOWN       108    /* Cannot send after transport endpoint shutdown */
+#define    ETOOMANYREFS    109    /* Too many references: cannot splice */
+#define    ETIMEDOUT       110    /* Connection timed out */
+#define    ECONNREFUSED    111    /* Connection refused */
+#define    EHOSTDOWN       112    /* Host is down */
+#define    EHOSTUNREACH    113    /* No route to host */
+#define    EALREADY        114    /* Operation already in progress */
+#define    EINPROGRESS     115    /* Operation now in progress */
+#define    ESTALE          116    /* Stale NFS file handle */
+#define    EUCLEAN         117    /* Structure needs cleaning */
+#define    ENOTNAM         118    /* Not a XENIX named type file */
+#define    ENAVAIL         119    /* No XENIX semaphores available */
+#define    EISNAM          120    /* Is a named type file */
+#define    EREMOTEIO       121    /* Remote I/O error */
+
+#endif /*_KTF_ERRNO_H */

--- a/include/lib.h
+++ b/include/lib.h
@@ -434,6 +434,17 @@ static inline void wait_cycles(unsigned int cycles) {
         cpu_relax();
 }
 
+static inline unsigned int next_power_of_two(unsigned int n) {
+    n--;
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    n++;
+    return n;
+}
+
 /* External declarations */
 
 extern void halt(void);

--- a/mm/slab.c
+++ b/mm/slab.c
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2020 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <ktf.h>
+#include <lib.h>
+#include <page.h>
+#include <console.h>
+#include <sched.h>
+#include <string.h>
+#include <processor.h>
+#include <smp/smp.h>
+#include <mm/vmm.h>
+#include <errno.h>
+#include <slab.h>
+
+/* List of meta slab pointers of each order */
+static list_head_t meta_slab_list[SLAB_ORDER_MAX];
+
+meta_slab_t global_meta_slab;
+
+static int initialize_slab(meta_slab_t *slab) {
+    int ret = 0;
+    unsigned int slab_count = 0, index = 0;
+    slab_t *current = NULL;
+
+    if (NULL == slab) {
+        dprintk("failed, NULL slab\n");
+        return -EINVAL;
+    }
+    
+    if (NULL == slab->slab_base) {
+        dprintk("failed, NULL base\n");
+        return -EINVAL;
+    }
+        
+    if (slab->slab_size > SLAB_SIZE_MAX) {
+        dprintk("failed, large slab size\n");
+        return -EINVAL;
+    }
+
+    if (slab->slab_size < SLAB_SIZE_8) {
+        dprintk("failed, small slab size\n");
+        return -EINVAL;
+    }
+
+    if ((slab->slab_size & (slab->slab_size - 1)) != 0) {
+        dprintk("failed, slab size not power of 2\n");
+        return -EINVAL;
+    }
+
+    slab_count = (slab->slab_len / slab->slab_size);
+    slab->next_free_slab = slab->slab_base;
+
+    current = slab->next_free_slab;
+    for (index = 1; index < slab_count; index++) {
+        current->next_slab = (slab_t *) (_ul(slab->slab_base) + (index*(slab->slab_size)));
+        current = current->next_slab;
+    }
+
+    return ret;
+}
+
+static void *slab_alloc(meta_slab_t *slab) {
+    void *allocated = NULL;
+    slab_t *next_free = NULL;
+
+    if (slab == NULL) {
+        dprintk("failed, NULL slab param\n");
+        return NULL;
+    }
+
+    /* TODO: Below should be done in thread-safe manner */
+    next_free = slab->next_free_slab;
+    allocated = next_free;
+    if (next_free) {
+        next_free = next_free->next_slab;
+    }
+    slab->next_free_slab = next_free;
+
+    return allocated;
+}
+
+static void slab_free(meta_slab_t *slab, void *ptr) {
+    slab_t *insert = NULL, *top = NULL;
+
+    if (slab == NULL || ptr == NULL) {
+        dprintk("NULL slab or ptr param\n");
+        return;
+    }
+
+	/* TODO: eventually below should be done in thread-safe manner */
+    insert = (slab_t *) ptr;
+    top = slab->next_free_slab;
+    insert->next_slab = top;
+    slab->next_free_slab = insert;
+}
+
+/*
+ * Round up to nearest power of 2
+ * If greater than max size or less than min size, return null
+ *
+ */
+void *ktf_alloc(unsigned int size) {
+    unsigned int size_power2 = 0, temp = 0, order_index = 0;
+    meta_slab_t *slab = NULL, *meta_slab = NULL;
+    void *alloc = NULL, *free_page = NULL;
+    int ret = 0;
+
+    size_power2 = next_power_of_two(size);
+    if (size_power2 > SLAB_SIZE_MAX || size_power2 < SLAB_SIZE_MIN) {
+        dprintk("failed, wrong slab size\n");
+        return NULL;
+    }
+
+    temp = size_power2;
+	order_index = log2(temp);
+	/* 
+     * Decrement it by 3 because min size is 8 bytes and thus min 
+     * index will be 3, and we need to index into zero based array 
+     */
+	order_index -= 3;
+
+    dprintk("Alloc size %lu, powerof 2 size %lu, order %lu\n", size, size_power2, order_index);
+    /* Go through list of meta_slab_t and try to allocate a free slab */
+    list_for_each_entry(slab, &meta_slab_list[order_index], list) {
+        alloc = slab_alloc(slab);
+        if (alloc != NULL)
+            return alloc;
+        /*
+         * TODO: add debug prints for diaganostics that we didn't get free slab
+         * and trying next page in the list
+         */
+    }
+
+    /* 
+     * If we reached here that means it's time to allocate a new meta_slab_t entry 
+     * and a new page to hold base address
+     */
+    meta_slab = slab_alloc(&global_meta_slab);
+    if (meta_slab == NULL) {
+        dprintk("failed, not enough free pages\n");
+        return NULL;
+    }
+
+    dprintk("meta_slab allocated %p\n", meta_slab);
+    
+    /*
+     * for now let's allocate 4K pages for all allocations,
+     * we can change the logic in future to have 2M for larger slab sizes
+     */
+    
+    free_page = get_free_pages(PAGE_ORDER_4K, GFP_KERNEL);
+    if (free_page == NULL) {
+        dprintk("ktf_alloc failed, not enough free pages\n");
+        slab_free(&global_meta_slab, meta_slab);
+        return NULL;
+    }
+    memset(free_page, 0, PAGE_SIZE);
+
+    meta_slab->slab_base = free_page;
+    meta_slab->slab_len = PAGE_SIZE;
+    meta_slab->slab_size = size_power2;
+    ret = initialize_slab(meta_slab);
+
+    if (ret != ESUCCESS) {
+        dprintk("initialize_slab failed\n");
+        put_pages(free_page, PAGE_ORDER_4K);
+        return NULL;
+
+    }
+
+    list_add(&meta_slab->list, &meta_slab_list[order_index]);
+    alloc = slab_alloc(meta_slab);
+
+    return alloc;
+}
+/*
+ * Loop through all the orders and check where does this memory belong
+ * Then link it back into free list. Not a O(1) of implementation but we're looking for simple now
+ *
+ */
+void ktf_free(void *ptr) {
+    int alloc_order;
+    meta_slab_t *slab = NULL;
+    
+    for (alloc_order = SLAB_ORDER_8; alloc_order < SLAB_ORDER_MAX; alloc_order++) {
+        /* Go through list of meta_slab_t and try to allocate a free slab */
+        list_for_each_entry(slab, &meta_slab_list[alloc_order], list) {
+            if ((_ul(ptr) >= (_ul(slab->slab_base))) &&
+                (_ul(ptr) < (_ul(slab->slab_base) + _ul(slab->slab_len)))) {
+                slab_free(slab, ptr);
+                return;
+            }
+        }
+    }
+
+    panic("Attempted to free %p and couldn't find it\n", ptr);
+    /* If we reached here, something terribly went wrong */
+    UNREACHABLE();
+}
+
+//#if 0
+static void slab_unit_tests(void) {
+    void *alloc1 = NULL, *alloc2 = NULL;
+
+    alloc1 = ktf_alloc(6);
+    printk("allocated buffer %p\n", alloc1);
+    alloc2 = ktf_alloc(7);
+    printk("allocated buffer %p\n", alloc2);
+    ktf_free(alloc1);
+    alloc1 = ktf_alloc(8);
+    printk("Re-allocated buffer %p\n", alloc1);
+    ktf_free(alloc1);
+    ktf_free(alloc2);
+
+    alloc1 = ktf_alloc(2043);
+    printk("allocated buffer %p\n", alloc1);
+    alloc2 = ktf_alloc(2040);
+    printk("allocated buffer %p\n", alloc2);
+    ktf_free(alloc1);
+    alloc1 = ktf_alloc(2048);
+    printk("Re-allocated buffer %p\n", alloc1);
+    ktf_free(alloc1);
+    ktf_free(alloc2);
+}
+//#endif
+
+int init_slab(void) {
+    int ret = 0;
+    int i = 0;
+    void *alloc_pages = NULL;
+
+	printk("Initialize SLAB\n");
+    memset(&meta_slab_list, 0, sizeof(meta_slab_list));    
+    memset(&global_meta_slab, 0, sizeof(global_meta_slab));
+
+    alloc_pages = get_free_pages(PAGE_ORDER_4K, GFP_KERNEL);
+    if (NULL == alloc_pages) {
+            dprintk("get_free_pages failed\n");
+            return -ENOMEM;
+    }
+    memset(alloc_pages, 0, PAGE_SIZE);
+
+    global_meta_slab.slab_base = alloc_pages;
+    global_meta_slab.slab_len = PAGE_SIZE;
+    global_meta_slab.slab_size = next_power_of_two(sizeof(meta_slab_t));
+    ret = initialize_slab(&global_meta_slab);
+    if (ret != ESUCCESS) {
+        dprintk("initialize_slab failed\n");
+        put_pages(alloc_pages, PAGE_ORDER_4K);
+        return ret;
+    }
+
+    for(i = SLAB_ORDER_8; i < SLAB_ORDER_MAX; i++) {
+        list_init(&meta_slab_list[i]);
+    }
+
+	slab_unit_tests();
+    dprintk("After initializing slab module\n");
+    return ret;
+}

--- a/setup.c
+++ b/setup.c
@@ -40,6 +40,7 @@
 #include <smp/smp.h>
 
 #include <drivers/serial.h>
+#include <slab.h>
 
 bool opt_debug;
 
@@ -104,6 +105,8 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic, multiboot_inf
     init_traps(0);
 
     zap_boot_mappings();
+
+    init_slab();
 
     init_apic(APIC_MODE_XAPIC);
 


### PR DESCRIPTION
Signed-off-by: Deepak Gupta <dkgupta@amazon.com>

*Issue #, if available:* #8 

*Description of changes:*

Slab allocator (slab.c/slab.h) uses 8, 16, 32, 64, 128, 256, 512, 1024, 2048 slabs.
As of now only 4K pages are being used. Free will be slow because there is a 
search for page to which it belongs and then freed, this can be optimized in future. 
It's not multi-threaded safe (so multiple tasks allocating/freeing can corrupt links), 
but spinlock can be added in future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
