### PR TITLE
style: add .clang-format config file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,133 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     90
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - 'for_each_memory_range'
+  - 'for_each_order'
+  - 'list_for_each'
+  - 'list_for_each_entry'
+  - 'list_for_each_entry_safe'
+  - 'list_for_each_safe'
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ vcpus=1
 
 You need to generate a bootable ISO for this.
 
+## Style
+
+The style for this project is defined in `.clang-format` file in the main directory of this repository.
+
+Use the following command to apply the style automatically to the file you modify:
+
+```
+clang-format -style=file -Werror -i MODIFIED_FILE
+```
+
+For more information refer to: https://clang.llvm.org/docs/ClangFormat.html
+
 ## Credits and Attributions
 
 * Parts of the KTF project are inspired by and based on XTF project [1] developed by Andrew Cooper of Citrix.

--- a/include/apic.h
+++ b/include/apic.h
@@ -32,9 +32,9 @@
 
 #define DEFAULT_APIC_BASE _U32(0xfee00000)
 
-#define APIC_BASE_BSP     (_U64(1) << 8)
-#define APIC_BASE_EXTD    (_U64(1) << 10)
-#define APIC_BASE_ENABLE  (_U64(1) << 11)
+#define APIC_BASE_BSP    (_U64(1) << 8)
+#define APIC_BASE_EXTD   (_U64(1) << 10)
+#define APIC_BASE_ENABLE (_U64(1) << 11)
 
 /* Local APIC definitions */
 #define APIC_ID                0x020
@@ -42,17 +42,17 @@
 #define APIC_SPIV              0x0f0
 #define APIC_SPIV_APIC_ENABLED 0x00100
 
-#define APIC_ICR               0x300
-#define APIC_ICR2              0x310
-#define APIC_LVT_TIMER         0x320
-#define APIC_LVT_LINT0         0x350
-#define APIC_LVT_LINT1         0x360
-#define APIC_DM_NMI            0x00400
-#define APIC_DM_INIT           0x00500
-#define APIC_DM_STARTUP        0x00600
-#define APIC_ICR_BUSY          0x01000
-#define APIC_DISABLE           0x10000
-#define APIC_DEST_SELF         0x40000
+#define APIC_ICR        0x300
+#define APIC_ICR2       0x310
+#define APIC_LVT_TIMER  0x320
+#define APIC_LVT_LINT0  0x350
+#define APIC_LVT_LINT1  0x360
+#define APIC_DM_NMI     0x00400
+#define APIC_DM_INIT    0x00500
+#define APIC_DM_STARTUP 0x00600
+#define APIC_ICR_BUSY   0x01000
+#define APIC_DISABLE    0x10000
+#define APIC_DEST_SELF  0x40000
 
 #define GET_APIC_DEST_FIELD(x) (((x) >> 24) & 0xFF)
 #define SET_APIC_DEST_FIELD(x) ((x) << 24)
@@ -88,7 +88,7 @@ static inline void apic_mmio_write(uint32_t reg, uint32_t val) {
 }
 
 static inline void apic_mmio_icr_write(uint64_t val) {
-    apic_mmio_write(APIC_ICR2, (uint32_t) (val >> 32));
+    apic_mmio_write(APIC_ICR2, (uint32_t)(val >> 32));
     apic_mmio_write(APIC_ICR, (uint32_t) val);
 }
 
@@ -117,7 +117,7 @@ static inline uint32_t apic_read(uint32_t reg) {
 
 static inline void apic_icr_write(uint64_t val) {
     if (apic_mode == APIC_MODE_XAPIC) {
-        apic_mmio_write(APIC_ICR2, (uint32_t) (val >> 32));
+        apic_mmio_write(APIC_ICR2, (uint32_t)(val >> 32));
         apic_mmio_write(APIC_ICR, (uint32_t) val);
     }
     else

--- a/include/asm-macros.h
+++ b/include/asm-macros.h
@@ -27,22 +27,22 @@
 #define KTF_ASM_MACROS_H
 
 #if defined(__i386__)
-#define _ASM_REG(reg) e ## reg
+#define _ASM_REG(reg) e##reg
 #elif defined(__x86_64__)
-#define _ASM_REG(reg) r ## reg
+#define _ASM_REG(reg) r##reg
 #else
 #define _ASM_REG(reg) reg
 #endif
 
-#define _ASM_AX _ASM_REG(ax)
-#define _ASM_BX _ASM_REG(bx)
-#define _ASM_CX _ASM_REG(cx)
-#define _ASM_DX _ASM_REG(dx)
-#define _ASM_SI _ASM_REG(si)
-#define _ASM_DI _ASM_REG(di)
-#define _ASM_BP _ASM_REG(bp)
-#define _ASM_SP _ASM_REG(sp)
-#define _ASM_IP _ASM_REG(ip)
+#define _ASM_AX    _ASM_REG(ax)
+#define _ASM_BX    _ASM_REG(bx)
+#define _ASM_CX    _ASM_REG(cx)
+#define _ASM_DX    _ASM_REG(dx)
+#define _ASM_SI    _ASM_REG(si)
+#define _ASM_DI    _ASM_REG(di)
+#define _ASM_BP    _ASM_REG(bp)
+#define _ASM_SP    _ASM_REG(sp)
+#define _ASM_IP    _ASM_REG(ip)
 #define _ASM_FLAGS _ASM_REG(flags)
 
 #ifdef __ASSEMBLY__

--- a/include/asm-macros.h
+++ b/include/asm-macros.h
@@ -47,6 +47,7 @@
 
 #ifdef __ASSEMBLY__
 
+/* clang-format off */
 .macro putc val
   movw $0x3f8, %dx;
   movb $\val, %al;
@@ -120,12 +121,13 @@ name:
     .section .note.name, "a";            \
     .align 4;                            \
     .long 2f - 1f; /* namesz */          \
-    .long 4f - 3f;  /* descsz */         \
+    .long 4f - 3f; /* descsz */          \
     .long type;    /* type   */          \
 1:.asciz #name;    /* name   */          \
 2:.align 4;                              \
 3:size addr;       /* desc   */          \
 4:.align 4;
+/* clang-format on */
 
 #endif
 

--- a/include/atomic.h
+++ b/include/atomic.h
@@ -33,13 +33,11 @@
 static inline bool test_bit(unsigned int bit, volatile void *addr) {
     bool status;
 
-    asm volatile (
-        "bt %[bit], %[addr];"
-        "setc %[status];"
-        : [status] "=r" (status)
-        : [bit] "Ir" (bit), [addr] "m" (* (uint8_t *) addr)
-        : "cc", "memory"
-    );
+    asm volatile("bt %[bit], %[addr];"
+                 "setc %[status];"
+                 : [ status ] "=r"(status)
+                 : [ bit ] "Ir"(bit), [ addr ] "m"(*(uint8_t *) addr)
+                 : "cc", "memory");
 
     return status;
 }
@@ -47,13 +45,11 @@ static inline bool test_bit(unsigned int bit, volatile void *addr) {
 static inline bool test_and_set_bit(unsigned int bit, volatile void *addr) {
     bool status;
 
-    asm volatile (
-        "lock bts %[bit], %[addr];"
-        "setc %[status];"
-        : [status] "=r" (status)
-        : [bit] "Ir" (bit), [addr] "m" (* (uint8_t *) addr)
-        : "cc", "memory"
-    );
+    asm volatile("lock bts %[bit], %[addr];"
+                 "setc %[status];"
+                 : [ status ] "=r"(status)
+                 : [ bit ] "Ir"(bit), [ addr ] "m"(*(uint8_t *) addr)
+                 : "cc", "memory");
 
     return status;
 }
@@ -61,13 +57,11 @@ static inline bool test_and_set_bit(unsigned int bit, volatile void *addr) {
 static inline bool test_and_reset_bit(unsigned int bit, volatile void *addr) {
     bool status;
 
-    asm volatile (
-        "lock btr %[bit], %[addr];"
-        "setc %[status];"
-        : [status] "=r" (status)
-        : [bit] "Ir" (bit), [addr] "m" (* (uint8_t *) addr)
-        : "cc", "memory"
-    );
+    asm volatile("lock btr %[bit], %[addr];"
+                 "setc %[status];"
+                 : [ status ] "=r"(status)
+                 : [ bit ] "Ir"(bit), [ addr ] "m"(*(uint8_t *) addr)
+                 : "cc", "memory");
 
     return status;
 }
@@ -75,13 +69,11 @@ static inline bool test_and_reset_bit(unsigned int bit, volatile void *addr) {
 static inline bool test_and_complement_bit(unsigned int bit, volatile void *addr) {
     bool status;
 
-    asm volatile (
-        "lock btc %[bit], %[addr];"
-        "setc %[status];"
-        : [status] "=r" (status)
-        : [bit] "Ir" (bit), [addr] "m" (* (uint8_t *) addr)
-        : "cc", "memory"
-    );
+    asm volatile("lock btc %[bit], %[addr];"
+                 "setc %[status];"
+                 : [ status ] "=r"(status)
+                 : [ bit ] "Ir"(bit), [ addr ] "m"(*(uint8_t *) addr)
+                 : "cc", "memory");
 
     return status;
 }

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -27,9 +27,9 @@
 #define KTF_COMPILER_H
 
 #define _STR(x) #x
-#define STR(x) _STR(x)
+#define STR(x)  _STR(x)
 
-#define _TOKEN(x, y) (x ## y)
+#define _TOKEN(x, y) (x##y)
 
 #ifdef __ASSEMBLY__
 #define _INTEGER(num, suffix) num
@@ -45,77 +45,83 @@
 #define GB(x) (_U64(x) << 30)
 
 #ifndef __ASSEMBLY__
-#define _ptr(val) ((void *)(unsigned long)(val))
-#define _ul(val) ((unsigned long)(val))
+#define _ptr(val) ((void *) (unsigned long) (val))
+#define _ul(val)  ((unsigned long) (val))
 #endif
 
-#define __aligned(x)    __attribute__((__aligned__(x)))
-#define __noreturn      __attribute__((__noreturn__))
-#define __packed        __attribute__((__packed__))
-#define __used          __attribute__((__used__))
-#define __noinline      __attribute__((__noinline__))
-#define __section(s)    __attribute__((__section__(s)))
+#define __aligned(x) __attribute__((__aligned__(x)))
+#define __noreturn   __attribute__((__noreturn__))
+#define __packed     __attribute__((__packed__))
+#define __used       __attribute__((__used__))
+#define __noinline   __attribute__((__noinline__))
+#define __section(s) __attribute__((__section__(s)))
 
-#define UNREACHABLE() do { __builtin_unreachable(); } while(0)
+#define UNREACHABLE()                                                                    \
+    do {                                                                                 \
+        __builtin_unreachable();                                                         \
+    } while (0)
 
 #define __text __section(".text")
 #define __data __section(".data")
-#define __bss __section(".bss")
+#define __bss  __section(".bss")
 
 #define __text_init __section(".text.init")
 #define __data_init __section(".data.init")
-#define __bss_init __section(".bss.init")
+#define __bss_init  __section(".bss.init")
 
 #define __user_text __section(".text.user")
 #define __user_data __section(".data.user")
-#define __user_bss __section(".bss.user")
+#define __user_bss  __section(".bss.user")
 
-#define barrier() asm volatile ("" ::: "memory")
-#define ACCESS_ONCE(x) (* (volatile typeof(x) *) &(x))
+#define barrier()      asm volatile("" ::: "memory")
+#define ACCESS_ONCE(x) (*(volatile typeof(x) *) &(x))
 
-#define likely(x)   __builtin_expect(!!(x),1)
-#define unlikely(x) __builtin_expect(!!(x),0)
+#define likely(x)   __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
 
 #ifndef offsetof
-#define offsetof(type, member) ((off_t) &((type *)0)->member)
+#define offsetof(type, member) ((off_t) & ((type *) 0)->member)
 #endif
 
 #define BUILD_BUG_ON(cond) ({ _Static_assert(!(cond), "!(" STR(cond) ")"); })
 
 #ifndef __same_type
-# define __same_type(a, b) __builtin_types_compatible_p(typeof(a), typeof(b))
+#define __same_type(a, b) __builtin_types_compatible_p(typeof(a), typeof(b))
 #endif
 
-#define container_of(ptr, type, member) ({                    \
-    void *_ptr = (void *) (ptr);                              \
-    BUILD_BUG_ON(!__same_type(*(ptr), ((type *)0)->member) && \
-                 !__same_type(*(ptr), void));                 \
-    ((type *) (_ptr - offsetof(type, member)));               \
-})
+#define container_of(ptr, type, member)                                                  \
+    ({                                                                                   \
+        void *_ptr = (void *) (ptr);                                                     \
+        BUILD_BUG_ON(!__same_type(*(ptr), ((type *) 0)->member) &&                       \
+                     !__same_type(*(ptr), void));                                        \
+        ((type *) (_ptr - offsetof(type, member)));                                      \
+    })
 
-#define ARRAY_SIZE(a)    (sizeof(a) / sizeof(*a))
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
 
 #define VA_NARGS_(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
 
-#define VA_NARGS(...) VA_NARGS_(_, ## __VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define VA_NARGS(...) VA_NARGS_(_, ##__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 
 #define COUNT_MACRO_ARGS__(macro, tok, count, ...) macro##count(tok, ##__VA_ARGS__)
-#define COUNT_MACRO_ARGS_(macro, tok, count, ...) COUNT_MACRO_ARGS__(macro, tok, count, ##__VA_ARGS__)
-#define COUNT_MACRO_ARGS(macro, tok, ...) COUNT_MACRO_ARGS_(macro, tok, VA_NARGS(__VA_ARGS__), ##__VA_ARGS__)
+#define COUNT_MACRO_ARGS_(macro, tok, count, ...)                                        \
+    COUNT_MACRO_ARGS__(macro, tok, count, ##__VA_ARGS__)
+#define COUNT_MACRO_ARGS(macro, tok, ...)                                                \
+    COUNT_MACRO_ARGS_(macro, tok, VA_NARGS(__VA_ARGS__), ##__VA_ARGS__)
 
 #define TOKEN_OR0(t)          (0)
-#define TOKEN_OR1(t, x)       (t ## x)
-#define TOKEN_OR2(t, x, ...)  (t ## x | TOKEN_OR1(t, ##__VA_ARGS__))
-#define TOKEN_OR3(t, x, ...)  (t ## x | TOKEN_OR2(t, ##__VA_ARGS__))
-#define TOKEN_OR4(t, x, ...)  (t ## x | TOKEN_OR3(t, ##__VA_ARGS__))
-#define TOKEN_OR5(t, x, ...)  (t ## x | TOKEN_OR4(t, ##__VA_ARGS__))
-#define TOKEN_OR6(t, x, ...)  (t ## x | TOKEN_OR5(t, ##__VA_ARGS__))
-#define TOKEN_OR7(t, x, ...)  (t ## x | TOKEN_OR6(t, ##__VA_ARGS__))
-#define TOKEN_OR8(t, x, ...)  (t ## x | TOKEN_OR7(t, ##__VA_ARGS__))
-#define TOKEN_OR9(t, x, ...)  (t ## x | TOKEN_OR8(t, ##__VA_ARGS__))
-#define TOKEN_OR10(t, x, ...) (t ## x | TOKEN_OR9(t, ##__VA_ARGS__))
-#define TOKEN_OR11(t, x, ...) (t ## x | TOKEN_OR10(t, ##__VA_ARGS__))
+#define TOKEN_OR1(t, x)       (t##x)
+#define TOKEN_OR2(t, x, ...)  (t##x | TOKEN_OR1(t, ##__VA_ARGS__))
+#define TOKEN_OR3(t, x, ...)  (t##x | TOKEN_OR2(t, ##__VA_ARGS__))
+#define TOKEN_OR4(t, x, ...)  (t##x | TOKEN_OR3(t, ##__VA_ARGS__))
+#define TOKEN_OR5(t, x, ...)  (t##x | TOKEN_OR4(t, ##__VA_ARGS__))
+#define TOKEN_OR6(t, x, ...)  (t##x | TOKEN_OR5(t, ##__VA_ARGS__))
+#define TOKEN_OR7(t, x, ...)  (t##x | TOKEN_OR6(t, ##__VA_ARGS__))
+#define TOKEN_OR8(t, x, ...)  (t##x | TOKEN_OR7(t, ##__VA_ARGS__))
+#define TOKEN_OR9(t, x, ...)  (t##x | TOKEN_OR8(t, ##__VA_ARGS__))
+#define TOKEN_OR10(t, x, ...) (t##x | TOKEN_OR9(t, ##__VA_ARGS__))
+#define TOKEN_OR11(t, x, ...) (t##x | TOKEN_OR10(t, ##__VA_ARGS__))
 
-#define TOKEN_OR(t, ...)     COUNT_MACRO_ARGS(TOKEN_OR, t, ##__VA_ARGS__)
+#define TOKEN_OR(t, ...) COUNT_MACRO_ARGS(TOKEN_OR, t, ##__VA_ARGS__)
 
 #endif /* KTF_COMPILER_H */

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -96,6 +96,7 @@
 #define ARRAY_SIZE(a)    (sizeof(a) / sizeof(*a))
 
 #define VA_NARGS_(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
+
 #define VA_NARGS(...) VA_NARGS_(_, ## __VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 
 #define COUNT_MACRO_ARGS__(macro, tok, count, ...) macro##count(tok, ##__VA_ARGS__)

--- a/include/console.h
+++ b/include/console.h
@@ -28,9 +28,11 @@
 typedef void (*console_callback_t)(const char *buf, size_t len);
 
 extern void printk(const char *fmt, ...);
-#define dprintk(fmt, ...) do {                   \
-    if (opt_debug) printk((fmt), ##__VA_ARGS__); \
-} while(0)
+#define dprintk(fmt, ...)                                                                \
+    do {                                                                                 \
+        if (opt_debug)                                                                   \
+            printk((fmt), ##__VA_ARGS__);                                                \
+    } while (0)
 
 extern void putchar(int c);
 

--- a/include/drivers/serial.h
+++ b/include/drivers/serial.h
@@ -30,11 +30,7 @@
 union line_control_register {
     uint8_t reg;
     struct __packed {
-        uint8_t width:2,
-                stop_bit:1,
-                parity:3,
-                break_ctrl:1,
-                DLAB:1;
+        uint8_t width : 2, stop_bit : 1, parity : 3, break_ctrl : 1, DLAB : 1;
     };
 };
 typedef union line_control_register lcr_t;
@@ -56,12 +52,7 @@ typedef union line_control_register lcr_t;
 union modem_control_register {
     uint8_t reg;
     struct __packed {
-        uint8_t dtr:1,
-                rts:1,
-                aux:2,
-                lo:1,
-                auto_flow:1,
-                rsvd:2;
+        uint8_t dtr : 1, rts : 1, aux : 2, lo : 1, auto_flow : 1, rsvd : 2;
     };
 };
 typedef union modem_control_register mcr_t;
@@ -69,14 +60,8 @@ typedef union modem_control_register mcr_t;
 union line_status_register {
     uint8_t reg;
     struct __packed {
-        uint8_t data_avl:1,
-                overrun_err:1,
-                parity_err:1,
-                framing_err:1,
-                break_sig:1,
-                thr_empty:1,
-                thr_empty_idle:1,
-                fifo_err:1;
+        uint8_t data_avl : 1, overrun_err : 1, parity_err : 1, framing_err : 1,
+            break_sig : 1, thr_empty : 1, thr_empty_idle : 1, fifo_err : 1;
     };
 };
 typedef union line_status_register lsr_t;
@@ -84,14 +69,8 @@ typedef union line_status_register lsr_t;
 union modem_status_register {
     uint8_t reg;
     struct __packed {
-        uint8_t cts_change:1,
-                dsr_change:1,
-                ri_change:1,
-                cd_change:1,
-                cts:1,
-                dsr:1,
-                ri:1,
-                cd:1;
+        uint8_t cts_change : 1, dsr_change : 1, ri_change : 1, cd_change : 1, cts : 1,
+            dsr : 1, ri : 1, cd : 1;
     };
 };
 typedef union modem_status_register msr_t;
@@ -99,13 +78,8 @@ typedef union modem_status_register msr_t;
 union fifo_control_register {
     uint8_t reg;
     struct __packed {
-        uint8_t enable:1,
-                clear_rx:1,
-                clear_tx:1,
-                dma_mode:1,
-                rsvd:1,
-                enable_64:1,
-                int_lvl:2;
+        uint8_t enable : 1, clear_rx : 1, clear_tx : 1, dma_mode : 1, rsvd : 1,
+            enable_64 : 1, int_lvl : 2;
     };
 };
 typedef union fifo_control_register fcr_t;
@@ -118,13 +92,8 @@ typedef union fifo_control_register fcr_t;
 union interrupt_enable_register {
     uint8_t reg;
     struct __packed {
-        uint8_t rx_avl:1,
-                thr_empty:1,
-                rx_lsr_change:1,
-                msr_change:1,
-                sleep_mode: 1,
-                low_pwr:1,
-                rsvd:2;
+        uint8_t rx_avl : 1, thr_empty : 1, rx_lsr_change : 1, msr_change : 1,
+            sleep_mode : 1, low_pwr : 1, rsvd : 2;
     };
 };
 typedef union interrupt_enable_register ier_t;
@@ -145,7 +114,7 @@ typedef union interrupt_enable_register ier_t;
 /* External declarations */
 
 extern void uart_init(io_port_t port, unsigned baud);
-extern int serial_putchar(io_port_t port, char c);
-extern int serial_write(io_port_t port, const char *buf, size_t len);
+extern int  serial_putchar(io_port_t port, char c);
+extern int  serial_write(io_port_t port, const char *buf, size_t len);
 
 #endif /* KTF_DRV_SERIAL_H */

--- a/include/drivers/vga.h
+++ b/include/drivers/vga.h
@@ -27,25 +27,25 @@
 
 #include <ktf.h>
 
-#define VGA_COLOR(bg, fg)       (((bg) << 4) | (fg))
+#define VGA_COLOR(bg, fg) (((bg) << 4) | (fg))
 
 enum vga_color {
-    VGA_BLACK          = 0x0,
-    VGA_BLUE           = 0x1,
-    VGA_GREEN          = 0x2,
-    VGA_CYAN           = 0x3,
-    VGA_RED            = 0x4,
-    VGA_MAGNETA        = 0x5,
-    VGA_BROWN          = 0x6,
-    VGA_LIGHT_GRAY     = 0x7,
-    VGA_GRAY           = 0x8,
-    VGA_LIGHT_BLUE     = 0x9,
-    VGA_LIGHT_GREEN    = 0xa,
-    VGA_LIGHT_CYAN     = 0xb,
-    VGA_LIGHT_RED      = 0xc,
-    VGA_LIGHT_MAGNETA  = 0xd,
-    VGA_YELLOW         = 0xe,
-    VGA_WHITE          = 0xf,
+    VGA_BLACK = 0x0,
+    VGA_BLUE = 0x1,
+    VGA_GREEN = 0x2,
+    VGA_CYAN = 0x3,
+    VGA_RED = 0x4,
+    VGA_MAGNETA = 0x5,
+    VGA_BROWN = 0x6,
+    VGA_LIGHT_GRAY = 0x7,
+    VGA_GRAY = 0x8,
+    VGA_LIGHT_BLUE = 0x9,
+    VGA_LIGHT_GREEN = 0xa,
+    VGA_LIGHT_CYAN = 0xb,
+    VGA_LIGHT_RED = 0xc,
+    VGA_LIGHT_MAGNETA = 0xd,
+    VGA_YELLOW = 0xe,
+    VGA_WHITE = 0xf,
 };
 typedef enum vga_color vga_color_t;
 

--- a/include/ktf.h
+++ b/include/ktf.h
@@ -25,12 +25,12 @@
 #ifndef KTF_KTF_H
 #define KTF_KTF_H
 
+#include <inttypes.h>
+#include <limits.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdarg.h>
-#include <inttypes.h>
-#include <limits.h>
 
 #include <compiler.h>
 

--- a/include/lib.h
+++ b/include/lib.h
@@ -25,22 +25,24 @@
 #ifndef KTF_LIB_H
 #define KTF_LIB_H
 
-#include <ktf.h>
-#include <console.h>
-#include <segment.h>
 #include <asm-macros.h>
+#include <console.h>
+#include <ktf.h>
+#include <segment.h>
 
-#define min(a, b) ({          \
-    const typeof(a) _a = (a); \
-    const typeof(b) _b = (b); \
-    _a < _b ? _a : _b;        \
-})
+#define min(a, b)                                                                        \
+    ({                                                                                   \
+        const typeof(a) _a = (a);                                                        \
+        const typeof(b) _b = (b);                                                        \
+        _a < _b ? _a : _b;                                                               \
+    })
 
-#define max(a, b) ({          \
-    const typeof(a) _a = (a); \
-    const typeof(b) _b = (b); \
-    _a > _b ? _a : _b;        \
-})
+#define max(a, b)                                                                        \
+    ({                                                                                   \
+        const typeof(a) _a = (a);                                                        \
+        const typeof(b) _b = (b);                                                        \
+        _a > _b ? _a : _b;                                                               \
+    })
 
 static inline unsigned int log2(unsigned int value) {
     return value == 0 ? 0 : (31 - __builtin_clz(value));
@@ -50,72 +52,59 @@ static inline unsigned int llog2(unsigned long value) {
     return value == 0 ? 0 : (63 - __builtin_clzl(value));
 }
 
-#define sfence() asm volatile ("sfence" ::: "memory")
-#define lfence() asm volatile ("lfence" ::: "memory")
-#define mfence() asm volatile ("mfence" ::: "memory")
+#define sfence() asm volatile("sfence" ::: "memory")
+#define lfence() asm volatile("lfence" ::: "memory")
+#define mfence() asm volatile("mfence" ::: "memory")
 
 #define mb()  mfence()
 #define rmb() lfence()
 #define wmb() sfence()
 
-#define smp_mb()  do {  mb(); barrier(); } while(0)
-#define smp_rmb() do { rmb(); barrier(); } while(0)
-#define smp_wmb() do { wmb(); barrier(); } while(0)
+#define smp_mb()                                                                         \
+    do {                                                                                 \
+        mb();                                                                            \
+        barrier();                                                                       \
+    } while (0)
+#define smp_rmb()                                                                        \
+    do {                                                                                 \
+        rmb();                                                                           \
+        barrier();                                                                       \
+    } while (0)
+#define smp_wmb()                                                                        \
+    do {                                                                                 \
+        wmb();                                                                           \
+        barrier();                                                                       \
+    } while (0)
 
 static inline void clflush(const volatile void *p) {
-    asm volatile (
-        "clflush %0"
-        :: "m" (*(char const *) p)
-        : "memory"
-    );
+    asm volatile("clflush %0" ::"m"(*(char const *) p) : "memory");
 }
 
 static inline void prefetchw(const void *p) {
-    asm volatile (
-        "prefetchw %0"
-        :: "m" (*(char const *) p)
-        : "memory"
-    );
+    asm volatile("prefetchw %0" ::"m"(*(char const *) p) : "memory");
 }
 
 static inline void prefetcht0(const void *p) {
-    asm volatile (
-        "prefetcht0 %0"
-        :: "m" (*(char const *) p)
-        : "memory"
-    );
+    asm volatile("prefetcht0 %0" ::"m"(*(char const *) p) : "memory");
 }
 
 static inline void prefetcht1(const void *p) {
-    asm volatile (
-        "prefetcht1 %0"
-        :: "m" (*(char const *) p)
-        : "memory"
-    );
+    asm volatile("prefetcht1 %0" ::"m"(*(char const *) p) : "memory");
 }
 
 static inline void prefetcht2(const void *p) {
-    asm volatile (
-        "prefetcht2 %0"
-        :: "m" (*(char const *) p)
-        : "memory"
-    );
+    asm volatile("prefetcht2 %0" ::"m"(*(char const *) p) : "memory");
 }
 
 static inline void prefetchnta(const void *p) {
-    asm volatile (
-        "prefetchnta %0"
-        :: "m" (*(char const *) p)
-        : "memory"
-    );
+    asm volatile("prefetchnta %0" ::"m"(*(char const *) p) : "memory");
 }
 
-static inline void cpuid(uint32_t leaf, uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx) {
-    asm volatile (
-        "cpuid"
-        : "=a" (*eax), "=b" (*ebx), "=c" (*ecx), "=d" (*edx)
-        : "0" (leaf), "1" (*ebx), "2" (*ecx), "3" (*edx)
-    );
+static inline void cpuid(uint32_t leaf, uint32_t *eax, uint32_t *ebx, uint32_t *ecx,
+                         uint32_t *edx) {
+    asm volatile("cpuid"
+                 : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx)
+                 : "0"(leaf), "1"(*ebx), "2"(*ecx), "3"(*edx));
 }
 
 static inline uint32_t cpuid_eax(uint32_t leaf) {
@@ -149,43 +138,28 @@ static inline uint32_t cpuid_edx(uint32_t leaf) {
 static inline uint64_t rdmsr(uint32_t msr_idx) {
     uint32_t low, high;
 
-    asm volatile (
-        "rdmsr"
-        : "=a" (low), "=d" (high)
-        : "c" (msr_idx)
-    );
+    asm volatile("rdmsr" : "=a"(low), "=d"(high) : "c"(msr_idx));
 
     return (((uint64_t) high) << 32) | low;
 }
 
 static inline void wrmsr(uint32_t msr_idx, uint64_t value) {
-    asm volatile (
-        "wrmsr"
-        :: "c" (msr_idx), "a" ((uint32_t) value),
-           "d" ((uint32_t) (value >> 32))
-    );
+    asm volatile("wrmsr" ::"c"(msr_idx), "a"((uint32_t) value),
+                 "d"((uint32_t)(value >> 32)));
 }
 
-static inline void sti(void) {
-    asm volatile ("sti");
-}
+static inline void sti(void) { asm volatile("sti"); }
 
-static inline void cli(void) {
-    asm volatile ("cli");
-}
+static inline void cli(void) { asm volatile("cli"); }
 
-static inline void pause(void) {
-    asm volatile ("pause");
-}
+static inline void pause(void) { asm volatile("pause"); }
 
-static inline void hlt(void) {
-    asm volatile ("hlt");
-}
+static inline void hlt(void) { asm volatile("hlt"); }
 
 static inline unsigned long read_flags(void) {
     unsigned long flags;
 
-    asm volatile (
+    asm volatile(
 #if defined(__i386__)
         "pushfd;"
         "popl %0"
@@ -193,8 +167,7 @@ static inline unsigned long read_flags(void) {
         "pushfq;"
         "popq %0"
 #endif
-        : "=r" (flags)
-    );
+        : "=r"(flags));
 
     return flags;
 }
@@ -202,7 +175,7 @@ static inline unsigned long read_flags(void) {
 static inline unsigned long read_cs(void) {
     unsigned long cs;
 
-    asm volatile ("mov %%cs, %0" : "=r" (cs));
+    asm volatile("mov %%cs, %0" : "=r"(cs));
 
     return cs;
 }
@@ -210,7 +183,7 @@ static inline unsigned long read_cs(void) {
 static inline unsigned long read_ds(void) {
     unsigned long ds;
 
-    asm volatile ("mov %%ds, %0" : "=r" (ds));
+    asm volatile("mov %%ds, %0" : "=r"(ds));
 
     return ds;
 }
@@ -218,7 +191,7 @@ static inline unsigned long read_ds(void) {
 static inline unsigned long read_ss(void) {
     unsigned long ss;
 
-    asm volatile ("mov %%ss, %0" : "=r" (ss));
+    asm volatile("mov %%ss, %0" : "=r"(ss));
 
     return ss;
 }
@@ -226,7 +199,7 @@ static inline unsigned long read_ss(void) {
 static inline unsigned long read_es(void) {
     unsigned long es;
 
-    asm volatile ("mov %%es, %0" : "=r" (es));
+    asm volatile("mov %%es, %0" : "=r"(es));
 
     return es;
 }
@@ -234,31 +207,27 @@ static inline unsigned long read_es(void) {
 static inline unsigned long read_fs(void) {
     unsigned long fs;
 
-    asm volatile ("mov %%fs, %0" : "=r" (fs));
+    asm volatile("mov %%fs, %0" : "=r"(fs));
 
     return fs;
 }
 
-static inline void write_fs(unsigned long fs) {
-    asm volatile ("mov %0, %%fs" :: "r" (fs));
-}
+static inline void write_fs(unsigned long fs) { asm volatile("mov %0, %%fs" ::"r"(fs)); }
 
 static inline unsigned long read_gs(void) {
     unsigned long gs;
 
-    asm volatile ("mov %%gs, %0" : "=r" (gs));
+    asm volatile("mov %%gs, %0" : "=r"(gs));
 
     return gs;
 }
 
-static inline void write_gs(unsigned long gs) {
-    asm volatile ("mov %0, %%gs" :: "r" (gs));
-}
+static inline void write_gs(unsigned long gs) { asm volatile("mov %0, %%gs" ::"r"(gs)); }
 
 static inline unsigned long read_cr0(void) {
     unsigned long cr0;
 
-    asm volatile ("mov %%cr0, %0" : "=r" (cr0));
+    asm volatile("mov %%cr0, %0" : "=r"(cr0));
 
     return cr0;
 }
@@ -266,7 +235,7 @@ static inline unsigned long read_cr0(void) {
 static inline unsigned long read_cr2(void) {
     unsigned long cr2;
 
-    asm volatile ("mov %%cr2, %0" : "=r" (cr2));
+    asm volatile("mov %%cr2, %0" : "=r"(cr2));
 
     return cr2;
 }
@@ -274,164 +243,130 @@ static inline unsigned long read_cr2(void) {
 static inline unsigned long read_cr3(void) {
     unsigned long cr3;
 
-    asm volatile ("mov %%cr3, %0" : "=r" (cr3));
+    asm volatile("mov %%cr3, %0" : "=r"(cr3));
 
     return cr3;
 }
 
 static inline void write_cr3(unsigned long cr3) {
-    asm volatile ("mov %0, %%cr3" :: "r" (cr3));
+    asm volatile("mov %0, %%cr3" ::"r"(cr3));
 }
 
 static inline unsigned long read_cr4(void) {
     unsigned long cr4;
 
-    asm volatile ("mov %%cr4, %0" : "=r" (cr4));
+    asm volatile("mov %%cr4, %0" : "=r"(cr4));
 
     return cr4;
 }
 
 static inline void write_cr4(unsigned long cr4) {
-    asm volatile ("mov %0, %%cr4" :: "r" (cr4));
+    asm volatile("mov %0, %%cr4" ::"r"(cr4));
 }
 
 static inline unsigned long read_cr8(void) {
     unsigned long cr8;
 
-    asm volatile ("mov %%cr8, %0" : "=r" (cr8));
+    asm volatile("mov %%cr8, %0" : "=r"(cr8));
 
     return cr8;
 }
 
 static inline void write_sp(void *sp) {
-    asm volatile (
-        "mov %0, %%" STR(_ASM_SP)
-        :: "r" (sp)
-        : "memory"
-    );
+    asm volatile("mov %0, %%" STR(_ASM_SP)::"r"(sp) : "memory");
 }
 
 static inline void lgdt(const gdt_ptr_t *gdt_ptr) {
-    asm volatile ("lgdt %0" :: "m" (*gdt_ptr));
+    asm volatile("lgdt %0" ::"m"(*gdt_ptr));
 }
 
 static inline void lidt(const idt_ptr_t *idt_ptr) {
-    asm volatile ("lidt %0" :: "m" (*idt_ptr));
+    asm volatile("lidt %0" ::"m"(*idt_ptr));
 }
 
 static inline void ltr(unsigned int selector) {
-    asm volatile ("ltr %w0" :: "rm" (selector));
+    asm volatile("ltr %w0" ::"rm"(selector));
 }
 
-static inline void sgdt(gdt_ptr_t *gdt_ptr) {
-    asm volatile ("sgdt %0" : "=m" (*gdt_ptr));
-}
+static inline void sgdt(gdt_ptr_t *gdt_ptr) { asm volatile("sgdt %0" : "=m"(*gdt_ptr)); }
 
-static inline void sidt(idt_ptr_t *idt_ptr) {
-    asm volatile ("sidt %0" : "=m" (*idt_ptr));
-}
+static inline void sidt(idt_ptr_t *idt_ptr) { asm volatile("sidt %0" : "=m"(*idt_ptr)); }
 
 static inline void str(unsigned int *selector) {
-    asm volatile ("str %0" : "=m" (*selector));
+    asm volatile("str %0" : "=m"(*selector));
 }
 
-static inline void flush_tlb(void) {
-    write_cr3(read_cr3());
-}
+static inline void flush_tlb(void) { write_cr3(read_cr3()); }
 
-static inline void ud2(void) {
-    asm volatile ("ud2");
-}
+static inline void ud2(void) { asm volatile("ud2"); }
 
-#define BUG() do { ud2(); } while(0)
-#define BUG_ON(cond) do { \
-    if ((cond)) BUG();    \
-} while(0)
+#define BUG()                                                                            \
+    do {                                                                                 \
+        ud2();                                                                           \
+    } while (0)
+#define BUG_ON(cond)                                                                     \
+    do {                                                                                 \
+        if ((cond))                                                                      \
+            BUG();                                                                       \
+    } while (0)
 
-#define ASSERT(cond) do {                       \
-    if (!(cond))                                \
-        panic("%s: Assert at %d failed: %s\n",  \
-              __func__, __LINE__, STR((cond))); \
-} while(0)
+#define ASSERT(cond)                                                                     \
+    do {                                                                                 \
+        if (!(cond))                                                                     \
+            panic("%s: Assert at %d failed: %s\n", __func__, __LINE__, STR((cond)));     \
+    } while (0)
 
 /* I/O Ports handling */
 
 static inline uint8_t inb(io_port_t port) {
     uint8_t value;
 
-    asm volatile (
-        "inb %1, %0"
-        : "=a" (value)
-        : "Nd" (port)
-    );
+    asm volatile("inb %1, %0" : "=a"(value) : "Nd"(port));
 
     return value;
 }
 
 static inline void outb(io_port_t port, uint8_t value) {
-    asm volatile (
-        "outb %0, %1"
-        :: "a" (value), "Nd" (port)
-    );
+    asm volatile("outb %0, %1" ::"a"(value), "Nd"(port));
 }
 
 static inline void outw(io_port_t port, uint16_t value) {
-    asm volatile (
-        "outw %0, %1"
-        :: "a" (value), "Nd" (port)
-    );
+    asm volatile("outw %0, %1" ::"a"(value), "Nd"(port));
 }
 
-static inline void putc(io_port_t port, int c) {
-    outb(port, c);
-}
+static inline void putc(io_port_t port, int c) { outb(port, c); }
 
 static inline void puts(io_port_t port, const char *buf, size_t len) {
-    asm volatile(
-        "rep; outsb"
-        : "+S" (buf), "+c" (len)
-        : "d" (port)
-    );
+    asm volatile("rep; outsb" : "+S"(buf), "+c"(len) : "d"(port));
 }
 
 /* I/O port delay is believed to take ~1ms */
 #define IO_DELAY_PORT 0x80
-static inline void io_delay(void) {
-    outb(IO_DELAY_PORT, 0xff); /* Random data write */
-}
+static inline void io_delay(void) { outb(IO_DELAY_PORT, 0xff); /* Random data write */ }
 
 static inline uint64_t rdtsc(void) {
-  unsigned int low, high;
+    unsigned int low, high;
 
-  asm volatile (
-      "rdtsc"
-      : "=a" (low), "=d" (high)
-  );
+    asm volatile("rdtsc" : "=a"(low), "=d"(high));
 
-  return ((uint64_t) high << 32) | low;
+    return ((uint64_t) high << 32) | low;
 }
 
 static inline uint64_t rdtscp(void) {
-  unsigned int low, high;
+    unsigned int low, high;
 
-  asm volatile (
-      "rdtscp"
-      : "=a" (low), "=d" (high)
-      :: "ecx"
-  );
+    asm volatile("rdtscp" : "=a"(low), "=d"(high)::"ecx");
 
-  return ((uint64_t) high << 32) | low;
+    return ((uint64_t) high << 32) | low;
 }
 
-static inline void rep_nop(void) {
-    asm volatile ("rep;nop" ::: "memory");
-}
+static inline void rep_nop(void) { asm volatile("rep;nop" ::: "memory"); }
 #define cpu_relax() rep_nop()
 
 static inline void wait_cycles(unsigned int cycles) {
     uint64_t start = rdtscp();
 
-    while(rdtscp() - start < cycles)
+    while (rdtscp() - start < cycles)
         cpu_relax();
 }
 

--- a/include/list.h
+++ b/include/list.h
@@ -29,8 +29,8 @@
 #include <lib.h>
 
 struct list_head {
-        struct list_head *next;
-        struct list_head *prev;
+    struct list_head *next;
+    struct list_head *prev;
 };
 typedef struct list_head list_head_t;
 
@@ -64,35 +64,30 @@ static inline void list_unlink(list_head_t *entry) {
     entry->prev = NULL;
 }
 
-static inline bool list_is_empty(list_head_t *list) {
-    return list->next == list;
-}
+static inline bool list_is_empty(list_head_t *list) { return list->next == list; }
 
 #define list_entry(elem, type, member) container_of(elem, type, member)
 
-#define list_next_entry(elem, member) list_entry((elem)->member.next, typeof(*(elem)), member)
-#define list_prev_entry(elem, member) list_entry((elem)->member.prev, typeof(*(elem)), member)
+#define list_next_entry(elem, member)                                                    \
+    list_entry((elem)->member.next, typeof(*(elem)), member)
+#define list_prev_entry(elem, member)                                                    \
+    list_entry((elem)->member.prev, typeof(*(elem)), member)
 
 #define list_first_entry(head, type, member) list_entry((head)->next, type, member)
-#define list_last_entry(head, type, member) list_entry((head)->prev, type, member)
+#define list_last_entry(head, type, member)  list_entry((head)->prev, type, member)
 
-#define list_for_each(ptr, head) \
-    for (ptr = (head)->next; ptr != (head); ptr = ptr->next)
+#define list_for_each(ptr, head) for (ptr = (head)->next; ptr != (head); ptr = ptr->next)
 
-#define list_for_each_safe(ptr, bak, head)    \
-    for (ptr = (head)->next, bak = ptr->next; \
-         ptr != (head);                       \
-         ptr = bak, bak = ptr->next)
+#define list_for_each_safe(ptr, bak, head)                                               \
+    for (ptr = (head)->next, bak = ptr->next; ptr != (head); ptr = bak, bak = ptr->next)
 
-#define list_for_each_entry(elem, head, member)                \
-    for (elem = list_first_entry(head, typeof(*elem), member); \
-         &elem->member != (head);                              \
+#define list_for_each_entry(elem, head, member)                                          \
+    for (elem = list_first_entry(head, typeof(*elem), member); &elem->member != (head);  \
          elem = list_next_entry(elem, member))
 
-#define list_for_each_entry_safe(elem, bak, head, member)      \
-    for (elem = list_first_entry(head, typeof(*elem), member), \
-         bak = list_next_entry(elem, member);                  \
-         &elem->member != (head);                              \
-         elem = bak, bak = list_next_entry(bak, member))
+#define list_for_each_entry_safe(elem, bak, head, member)                                \
+    for (elem = list_first_entry(head, typeof(*elem), member),                           \
+        bak = list_next_entry(elem, member);                                             \
+         &elem->member != (head); elem = bak, bak = list_next_entry(bak, member))
 
 #endif /* KTF_LIST_H */

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -39,7 +39,7 @@
 
 extern unsigned long __start_text[], __end_text[];
 extern unsigned long __start_data[], __end_data[];
-extern unsigned long __start_bss[],  __end_bss[];
+extern unsigned long __start_bss[], __end_bss[];
 extern unsigned long __start_rodata[], __end_rodata[];
 
 extern unsigned long __start_text_user[], __end_text_user[];
@@ -53,57 +53,51 @@ extern unsigned long __start_bss_init[], __end_bss_init[];
 extern unsigned long __start_rmode[], __end_rmode[];
 
 struct addr_range {
-    const char *name;
+    const char *  name;
     unsigned long base;
     unsigned long flags;
-    void *start;
-    void *end;
+    void *        start;
+    void *        end;
 };
 typedef struct addr_range addr_range_t;
 
 extern addr_range_t addr_ranges[];
-#define for_each_memory_range(ptr)                                    \
-    for (addr_range_t *ptr = &addr_ranges[0];                         \
-         ptr->name != NULL || (ptr->start != 0x0 && ptr->end != 0x0); \
-         ptr++)
+#define for_each_memory_range(ptr)                                                       \
+    for (addr_range_t *ptr = &addr_ranges[0];                                            \
+         ptr->name != NULL || (ptr->start != 0x0 && ptr->end != 0x0); ptr++)
 
 struct frame {
     struct list_head list;
-    mfn_t mfn;
-    uint32_t refcount;
-    uint32_t :24, order:6, uncachable:1, free:1;
+    mfn_t            mfn;
+    uint32_t         refcount;
+    uint32_t : 24, order : 6, uncachable : 1, free : 1;
 };
 typedef struct frame frame_t;
 
-#define for_each_order(order) \
-    for (int order = 0; order < MAX_PAGE_ORDER + 1; order++)
+#define for_each_order(order) for (int order = 0; order < MAX_PAGE_ORDER + 1; order++)
 
 /* External definitions */
 
 extern void display_memory_map(void);
 
 extern addr_range_t get_memory_range(paddr_t pa);
-extern paddr_t get_memory_range_start(paddr_t pa);
-extern paddr_t get_memory_range_end(paddr_t pa);
+extern paddr_t      get_memory_range_start(paddr_t pa);
+extern paddr_t      get_memory_range_end(paddr_t pa);
 
 extern bool paddr_invalid(paddr_t pa);
 
 extern void init_pmm(void);
 
 extern mfn_t get_free_frames(unsigned int order);
-extern void put_frame(mfn_t mfn, unsigned int order);
+extern void  put_frame(mfn_t mfn, unsigned int order);
 
 extern void map_used_memory(void);
 
 /* Static definitions */
 
-static inline bool mfn_invalid(mfn_t mfn) {
-    return paddr_invalid(mfn_to_paddr(mfn));
-}
+static inline bool mfn_invalid(mfn_t mfn) { return paddr_invalid(mfn_to_paddr(mfn)); }
 
-static inline mfn_t get_free_frame(void) {
-    return get_free_frames(PAGE_ORDER_4K);
-}
+static inline mfn_t get_free_frame(void) { return get_free_frames(PAGE_ORDER_4K); }
 
 #endif /* __ASSEMBLY__ */
 

--- a/include/mm/vmm.h
+++ b/include/mm/vmm.h
@@ -28,15 +28,15 @@
 #include <page.h>
 
 enum gfp_flags {
-    GFP_KERNEL  = 0x00000001,
-    GFP_USER    = 0x00000002,
-    GFP_IDENT   = 0x00000004,
+    GFP_KERNEL = 0x00000001,
+    GFP_USER = 0x00000002,
+    GFP_IDENT = 0x00000004,
 };
 
 /* External definitions */
 
 extern void *get_free_pages(unsigned int order, uint32_t flags);
-extern void put_pages(void *page, unsigned int order);
+extern void  put_pages(void *page, unsigned int order);
 
 /* Static definitions */
 
@@ -52,8 +52,6 @@ static inline void *get_free_page_top(uint32_t flags) {
     return get_free_page(flags) + PAGE_SIZE;
 }
 
-static inline void put_page(void *page) {
-    put_pages(page, PAGE_ORDER_4K);
-}
+static inline void put_page(void *page) { put_pages(page, PAGE_ORDER_4K); }
 
 #endif /* KTF_VMM_H */

--- a/include/multiboot.h
+++ b/include/multiboot.h
@@ -26,248 +26,236 @@
 #define MULTIBOOT_HEADER 1
 
 /* How many bytes from the start of the file we search for the header.  */
-#define MULTIBOOT_SEARCH                        8192
-#define MULTIBOOT_HEADER_ALIGN                  4
+#define MULTIBOOT_SEARCH       8192
+#define MULTIBOOT_HEADER_ALIGN 4
 
 /* The magic field should contain this.  */
-#define MULTIBOOT_HEADER_MAGIC                  0x1BADB002
+#define MULTIBOOT_HEADER_MAGIC 0x1BADB002
 
 /* This should be in %eax.  */
-#define MULTIBOOT_BOOTLOADER_MAGIC              0x2BADB002
+#define MULTIBOOT_BOOTLOADER_MAGIC 0x2BADB002
 
 /* Alignment of multiboot modules.  */
-#define MULTIBOOT_MOD_ALIGN                     0x00001000
+#define MULTIBOOT_MOD_ALIGN 0x00001000
 
 /* Alignment of the multiboot info structure.  */
-#define MULTIBOOT_INFO_ALIGN                    0x00000004
+#define MULTIBOOT_INFO_ALIGN 0x00000004
 
 /* Flags set in the 'flags' member of the multiboot header.  */
 
 /* Align all boot modules on i386 page (4KB) boundaries.  */
-#define MULTIBOOT_PAGE_ALIGN                    0x00000001
+#define MULTIBOOT_PAGE_ALIGN 0x00000001
 
 /* Must pass memory information to OS.  */
-#define MULTIBOOT_MEMORY_INFO                   0x00000002
+#define MULTIBOOT_MEMORY_INFO 0x00000002
 
 /* Must pass video information to OS.  */
-#define MULTIBOOT_VIDEO_MODE                    0x00000004
+#define MULTIBOOT_VIDEO_MODE 0x00000004
 
 /* This flag indicates the use of the address fields in the header.  */
-#define MULTIBOOT_AOUT_KLUDGE                   0x00010000
+#define MULTIBOOT_AOUT_KLUDGE 0x00010000
 
 /* Flags to be set in the 'flags' member of the multiboot info structure.  */
 
 /* is there basic lower/upper memory information? */
-#define MULTIBOOT_INFO_MEMORY                   0x00000001
+#define MULTIBOOT_INFO_MEMORY 0x00000001
 /* is there a boot device set? */
-#define MULTIBOOT_INFO_BOOTDEV                  0x00000002
+#define MULTIBOOT_INFO_BOOTDEV 0x00000002
 /* is the command-line defined? */
-#define MULTIBOOT_INFO_CMDLINE                  0x00000004
+#define MULTIBOOT_INFO_CMDLINE 0x00000004
 /* are there modules to do something with? */
-#define MULTIBOOT_INFO_MODS                     0x00000008
+#define MULTIBOOT_INFO_MODS 0x00000008
 
 /* These next two are mutually exclusive */
 
 /* is there a symbol table loaded? */
-#define MULTIBOOT_INFO_AOUT_SYMS                0x00000010
+#define MULTIBOOT_INFO_AOUT_SYMS 0x00000010
 /* is there an ELF section header table? */
-#define MULTIBOOT_INFO_ELF_SHDR                 0x00000020
+#define MULTIBOOT_INFO_ELF_SHDR 0x00000020
 
 /* is there a full memory map? */
-#define MULTIBOOT_INFO_MEM_MAP                  0x00000040
+#define MULTIBOOT_INFO_MEM_MAP 0x00000040
 
 /* Is there drive info?  */
-#define MULTIBOOT_INFO_DRIVE_INFO               0x00000080
+#define MULTIBOOT_INFO_DRIVE_INFO 0x00000080
 
 /* Is there a config table?  */
-#define MULTIBOOT_INFO_CONFIG_TABLE             0x00000100
+#define MULTIBOOT_INFO_CONFIG_TABLE 0x00000100
 
 /* Is there a boot loader name?  */
-#define MULTIBOOT_INFO_BOOT_LOADER_NAME         0x00000200
+#define MULTIBOOT_INFO_BOOT_LOADER_NAME 0x00000200
 
 /* Is there a APM table?  */
-#define MULTIBOOT_INFO_APM_TABLE                0x00000400
+#define MULTIBOOT_INFO_APM_TABLE 0x00000400
 
 /* Is there video information?  */
-#define MULTIBOOT_INFO_VBE_INFO                 0x00000800
-#define MULTIBOOT_INFO_FRAMEBUFFER_INFO         0x00001000
+#define MULTIBOOT_INFO_VBE_INFO         0x00000800
+#define MULTIBOOT_INFO_FRAMEBUFFER_INFO 0x00001000
 
 #ifndef ASM_FILE
 
 #include <stdint.h>
 
-struct multiboot_header
-{
-  /* Must be MULTIBOOT_MAGIC - see above.  */
-  uint32_t magic;
+struct multiboot_header {
+    /* Must be MULTIBOOT_MAGIC - see above.  */
+    uint32_t magic;
 
-  /* Feature flags.  */
-  uint32_t flags;
+    /* Feature flags.  */
+    uint32_t flags;
 
-  /* The above fields plus this one must equal 0 mod 2^32. */
-  uint32_t checksum;
+    /* The above fields plus this one must equal 0 mod 2^32. */
+    uint32_t checksum;
 
-  /* These are only valid if MULTIBOOT_AOUT_KLUDGE is set.  */
-  uint32_t header_addr;
-  uint32_t load_addr;
-  uint32_t load_end_addr;
-  uint32_t bss_end_addr;
-  uint32_t entry_addr;
+    /* These are only valid if MULTIBOOT_AOUT_KLUDGE is set.  */
+    uint32_t header_addr;
+    uint32_t load_addr;
+    uint32_t load_end_addr;
+    uint32_t bss_end_addr;
+    uint32_t entry_addr;
 
-  /* These are only valid if MULTIBOOT_VIDEO_MODE is set.  */
-  uint32_t mode_type;
-  uint32_t width;
-  uint32_t height;
-  uint32_t depth;
+    /* These are only valid if MULTIBOOT_VIDEO_MODE is set.  */
+    uint32_t mode_type;
+    uint32_t width;
+    uint32_t height;
+    uint32_t depth;
 };
 
 /* The symbol table for a.out.  */
-struct multiboot_aout_symbol_table
-{
-  uint32_t tabsize;
-  uint32_t strsize;
-  uint32_t addr;
-  uint32_t reserved;
+struct multiboot_aout_symbol_table {
+    uint32_t tabsize;
+    uint32_t strsize;
+    uint32_t addr;
+    uint32_t reserved;
 };
 typedef struct multiboot_aout_symbol_table multiboot_aout_symbol_table_t;
 
 /* The section header table for ELF.  */
-struct multiboot_elf_section_header_table
-{
-  uint32_t num;
-  uint32_t size;
-  uint32_t addr;
-  uint32_t shndx;
+struct multiboot_elf_section_header_table {
+    uint32_t num;
+    uint32_t size;
+    uint32_t addr;
+    uint32_t shndx;
 };
 typedef struct multiboot_elf_section_header_table multiboot_elf_section_header_table_t;
 
-struct multiboot_info
-{
-  /* Multiboot info version number */
-  uint32_t flags;
+struct multiboot_info {
+    /* Multiboot info version number */
+    uint32_t flags;
 
-  /* Available memory from BIOS */
-  uint32_t mem_lower;
-  uint32_t mem_upper;
+    /* Available memory from BIOS */
+    uint32_t mem_lower;
+    uint32_t mem_upper;
 
-  /* "root" partition */
-  uint32_t boot_device;
+    /* "root" partition */
+    uint32_t boot_device;
 
-  /* Kernel command line */
-  uint32_t cmdline;
+    /* Kernel command line */
+    uint32_t cmdline;
 
-  /* Boot-Module list */
-  uint32_t mods_count;
-  uint32_t mods_addr;
+    /* Boot-Module list */
+    uint32_t mods_count;
+    uint32_t mods_addr;
 
-  union
-  {
-    multiboot_aout_symbol_table_t aout_sym;
-    multiboot_elf_section_header_table_t elf_sec;
-  } u;
+    union {
+        multiboot_aout_symbol_table_t        aout_sym;
+        multiboot_elf_section_header_table_t elf_sec;
+    } u;
 
-  /* Memory Mapping buffer */
-  uint32_t mmap_length;
-  uint32_t mmap_addr;
+    /* Memory Mapping buffer */
+    uint32_t mmap_length;
+    uint32_t mmap_addr;
 
-  /* Drive Info buffer */
-  uint32_t drives_length;
-  uint32_t drives_addr;
+    /* Drive Info buffer */
+    uint32_t drives_length;
+    uint32_t drives_addr;
 
-  /* ROM configuration table */
-  uint32_t config_table;
+    /* ROM configuration table */
+    uint32_t config_table;
 
-  /* Boot Loader Name */
-  uint32_t boot_loader_name;
+    /* Boot Loader Name */
+    uint32_t boot_loader_name;
 
-  /* APM table */
-  uint32_t apm_table;
+    /* APM table */
+    uint32_t apm_table;
 
-  /* Video */
-  uint32_t vbe_control_info;
-  uint32_t vbe_mode_info;
-  uint16_t vbe_mode;
-  uint16_t vbe_interface_seg;
-  uint16_t vbe_interface_off;
-  uint16_t vbe_interface_len;
+    /* Video */
+    uint32_t vbe_control_info;
+    uint32_t vbe_mode_info;
+    uint16_t vbe_mode;
+    uint16_t vbe_interface_seg;
+    uint16_t vbe_interface_off;
+    uint16_t vbe_interface_len;
 
-  uint64_t framebuffer_addr;
-  uint32_t framebuffer_pitch;
-  uint32_t framebuffer_width;
-  uint32_t framebuffer_height;
-  uint8_t framebuffer_bpp;
-#define MULTIBOOT_FRAMEBUFFER_TYPE_INDEXED      0
-#define MULTIBOOT_FRAMEBUFFER_TYPE_RGB          1
-#define MULTIBOOT_FRAMEBUFFER_TYPE_EGA_TEXT     2
-  uint8_t framebuffer_type;
-  union
-  {
-    struct
-    {
-      uint32_t framebuffer_palette_addr;
-      uint16_t framebuffer_palette_num_colors;
+    uint64_t framebuffer_addr;
+    uint32_t framebuffer_pitch;
+    uint32_t framebuffer_width;
+    uint32_t framebuffer_height;
+    uint8_t  framebuffer_bpp;
+#define MULTIBOOT_FRAMEBUFFER_TYPE_INDEXED  0
+#define MULTIBOOT_FRAMEBUFFER_TYPE_RGB      1
+#define MULTIBOOT_FRAMEBUFFER_TYPE_EGA_TEXT 2
+    uint8_t framebuffer_type;
+    union {
+        struct {
+            uint32_t framebuffer_palette_addr;
+            uint16_t framebuffer_palette_num_colors;
+        };
+        struct {
+            uint8_t framebuffer_red_field_position;
+            uint8_t framebuffer_red_mask_size;
+            uint8_t framebuffer_green_field_position;
+            uint8_t framebuffer_green_mask_size;
+            uint8_t framebuffer_blue_field_position;
+            uint8_t framebuffer_blue_mask_size;
+        };
     };
-    struct
-    {
-      uint8_t framebuffer_red_field_position;
-      uint8_t framebuffer_red_mask_size;
-      uint8_t framebuffer_green_field_position;
-      uint8_t framebuffer_green_mask_size;
-      uint8_t framebuffer_blue_field_position;
-      uint8_t framebuffer_blue_mask_size;
-    };
-  };
 };
 typedef struct multiboot_info multiboot_info_t;
 
-struct multiboot_color
-{
-  uint8_t red;
-  uint8_t green;
-  uint8_t blue;
+struct multiboot_color {
+    uint8_t red;
+    uint8_t green;
+    uint8_t blue;
 };
 
-struct multiboot_mmap_entry
-{
-  uint32_t size;
-  uint64_t addr;
-  uint64_t len;
-#define MULTIBOOT_MEMORY_UNDEFINED              0
-#define MULTIBOOT_MEMORY_AVAILABLE              1
-#define MULTIBOOT_MEMORY_RESERVED               2
-#define MULTIBOOT_MEMORY_ACPI_RECLAIMABLE       3
-#define MULTIBOOT_MEMORY_NVS                    4
-#define MULTIBOOT_MEMORY_BADRAM                 5
-  uint32_t type;
+struct multiboot_mmap_entry {
+    uint32_t size;
+    uint64_t addr;
+    uint64_t len;
+#define MULTIBOOT_MEMORY_UNDEFINED        0
+#define MULTIBOOT_MEMORY_AVAILABLE        1
+#define MULTIBOOT_MEMORY_RESERVED         2
+#define MULTIBOOT_MEMORY_ACPI_RECLAIMABLE 3
+#define MULTIBOOT_MEMORY_NVS              4
+#define MULTIBOOT_MEMORY_BADRAM           5
+    uint32_t type;
 } __attribute__((packed));
 typedef struct multiboot_mmap_entry multiboot_memory_map_t;
 
-struct multiboot_mod_list
-{
-  /* the memory used goes from bytes 'mod_start' to 'mod_end-1' inclusive */
-  uint32_t mod_start;
-  uint32_t mod_end;
+struct multiboot_mod_list {
+    /* the memory used goes from bytes 'mod_start' to 'mod_end-1' inclusive */
+    uint32_t mod_start;
+    uint32_t mod_end;
 
-  /* Module command line */
-  uint32_t cmdline;
+    /* Module command line */
+    uint32_t cmdline;
 
-  /* padding to take it to 16 bytes (must be zero) */
-  uint32_t pad;
+    /* padding to take it to 16 bytes (must be zero) */
+    uint32_t pad;
 };
 typedef struct multiboot_mod_list multiboot_module_t;
 
 /* APM BIOS info.  */
-struct multiboot_apm_info
-{
-  uint16_t version;
-  uint16_t cseg;
-  uint32_t offset;
-  uint16_t cseg_16;
-  uint16_t dseg;
-  uint16_t flags;
-  uint16_t cseg_len;
-  uint16_t cseg_16_len;
-  uint16_t dseg_len;
+struct multiboot_apm_info {
+    uint16_t version;
+    uint16_t cseg;
+    uint32_t offset;
+    uint16_t cseg_16;
+    uint16_t dseg;
+    uint16_t flags;
+    uint16_t cseg_len;
+    uint16_t cseg_16_len;
+    uint16_t dseg_len;
 };
 
 #endif /* ! ASM_FILE */
@@ -302,10 +290,10 @@ struct multiboot_apm_info
 extern void display_multiboot_mmap(void);
 extern void init_multiboot(multiboot_info_t *mbi, const char **cmdline);
 
-#include <page.h>
 #include <mm/pmm.h>
+#include <page.h>
 extern unsigned mbi_get_avail_memory_ranges_num(void);
-extern int mbi_get_avail_memory_range(unsigned index, addr_range_t *r);
-extern int mbi_get_memory_range(paddr_t pa, addr_range_t *r);
+extern int      mbi_get_avail_memory_range(unsigned index, addr_range_t *r);
+extern int      mbi_get_memory_range(paddr_t pa, addr_range_t *r);
 
 #endif /* KTF_MULTIBOOT_H */

--- a/include/page.h
+++ b/include/page.h
@@ -27,9 +27,9 @@
 
 #include <compiler.h>
 
-#define PAGE_SHIFT 12
-#define PAGE_SIZE  (_U64(1) << PAGE_SHIFT)
-#define PAGE_MASK  (~(PAGE_SIZE - 1))
+#define PAGE_SHIFT    12
+#define PAGE_SIZE     (_U64(1) << PAGE_SHIFT)
+#define PAGE_MASK     (~(PAGE_SIZE - 1))
 #define PAGE_ORDER_4K 0
 
 #define PAGE_SHIFT_2M 21
@@ -44,25 +44,24 @@
 
 #define MAX_PAGE_ORDER PAGE_ORDER_1G
 
-#define _PAGE_PRESENT           0x0001
-#define _PAGE_RW                0x0002
-#define _PAGE_USER              0x0004
-#define _PAGE_PWT               0x0008
-#define _PAGE_PCD               0x0010
-#define _PAGE_ACCESSED          0x0020
-#define _PAGE_DIRTY             0x0040
-#define _PAGE_AD                (_PAGE_ACCESSED | _PAGE_DIRTY)
-#define _PAGE_PSE               0x0080
-#define _PAGE_PAT               0x0080
-#define _PAGE_GLOBAL            0x0100
-#define _PAGE_AVAIL             0x0e00
-#define _PAGE_PSE_PAT           0x1000
-#define _PAGE_NX                (_U64(1) << 63)
+#define _PAGE_PRESENT  0x0001
+#define _PAGE_RW       0x0002
+#define _PAGE_USER     0x0004
+#define _PAGE_PWT      0x0008
+#define _PAGE_PCD      0x0010
+#define _PAGE_ACCESSED 0x0020
+#define _PAGE_DIRTY    0x0040
+#define _PAGE_AD       (_PAGE_ACCESSED | _PAGE_DIRTY)
+#define _PAGE_PSE      0x0080
+#define _PAGE_PAT      0x0080
+#define _PAGE_GLOBAL   0x0100
+#define _PAGE_AVAIL    0x0e00
+#define _PAGE_PSE_PAT  0x1000
+#define _PAGE_NX       (_U64(1) << 63)
 
-#define _PAGE_ALL_FLAGS \
-    (_PAGE_PRESENT | _PAGE_RW  | _PAGE_USER | _PAGE_PWT    | \
-     _PAGE_PCD     | _PAGE_AD  | _PAGE_PAT  | _PAGE_GLOBAL | \
-     _PAGE_PSE_PAT | _PAGE_NX)
+#define _PAGE_ALL_FLAGS                                                                  \
+    (_PAGE_PRESENT | _PAGE_RW | _PAGE_USER | _PAGE_PWT | _PAGE_PCD | _PAGE_AD |          \
+     _PAGE_PAT | _PAGE_GLOBAL | _PAGE_PSE_PAT | _PAGE_NX)
 
 #define PTE_FLAGS(...) (TOKEN_OR(_PAGE_, ##__VA_ARGS__))
 
@@ -88,9 +87,9 @@
 #define L4_PROT_USER_RO (L4_PROT_RO | _PAGE_USER)
 
 #define PTE_ORDER 3
-#define PTE_SIZE (_U32(1) << PTE_ORDER)
+#define PTE_SIZE  (_U32(1) << PTE_ORDER)
 
-#define PT_ORDER 9
+#define PT_ORDER    9
 #define L1_PT_SHIFT PAGE_SHIFT
 #define L2_PT_SHIFT (L1_PT_SHIFT + PT_ORDER)
 #define L3_PT_SHIFT (L2_PT_SHIFT + PT_ORDER)
@@ -98,7 +97,7 @@
 
 #define L1_PT_ENTRIES (PAGE_SIZE / PTE_SIZE)
 #define L2_PT_ENTRIES (PAGE_SIZE / PTE_SIZE)
-#if defined (__x86_64__)
+#if defined(__x86_64__)
 #define L3_PT_ENTRIES (PAGE_SIZE / PTE_SIZE)
 #define L4_PT_ENTRIES (PAGE_SIZE / PTE_SIZE)
 #elif defined(__i386__)
@@ -111,8 +110,8 @@
 #define L4_MAP_SPACE (L4_PT_ENTRIES * L3_MAP_SPACE)
 
 #define PADDR_SHIFT 52
-#define PADDR_SIZE (_U64(1) << PADDR_SHIFT)
-#define PADDR_MASK (~(PADDR_SIZE - 1))
+#define PADDR_SIZE  (_U64(1) << PADDR_SHIFT)
+#define PADDR_MASK  (~(PADDR_SIZE - 1))
 
 #define VIRT_KERNEL_BASE _U64(0xffffffff80000000)
 #define VIRT_USER_BASE   _U64(0x0000000000400000)
@@ -126,21 +125,31 @@ typedef unsigned long mfn_t;
 #define _paddr(addr) ((paddr_t) _ul(addr))
 
 #define PADDR_INVALID (0UL)
-#define MFN_INVALID (0UL)
+#define MFN_INVALID   (0UL)
 
-static inline mfn_t paddr_to_mfn(paddr_t pa)  { return (mfn_t) (pa >> PAGE_SHIFT);    }
-static inline paddr_t mfn_to_paddr(mfn_t mfn) { return (paddr_t) (mfn << PAGE_SHIFT); }
+static inline mfn_t   paddr_to_mfn(paddr_t pa) { return (mfn_t)(pa >> PAGE_SHIFT); }
+static inline paddr_t mfn_to_paddr(mfn_t mfn) { return (paddr_t)(mfn << PAGE_SHIFT); }
 
 static inline void *_paddr_to_virt(paddr_t pa, unsigned long addr_space) {
     return _ptr(pa + addr_space);
 }
-static inline void *paddr_to_virt_kern(paddr_t pa) { return _paddr_to_virt(pa, VIRT_KERNEL_BASE); }
-static inline void *paddr_to_virt_user(paddr_t pa) { return _paddr_to_virt(pa, VIRT_USER_BASE);   }
-static inline void *paddr_to_virt(paddr_t pa)      { return _paddr_to_virt(pa, VIRT_IDENT_BASE);  }
+static inline void *paddr_to_virt_kern(paddr_t pa) {
+    return _paddr_to_virt(pa, VIRT_KERNEL_BASE);
+}
+static inline void *paddr_to_virt_user(paddr_t pa) {
+    return _paddr_to_virt(pa, VIRT_USER_BASE);
+}
+static inline void *paddr_to_virt(paddr_t pa) {
+    return _paddr_to_virt(pa, VIRT_IDENT_BASE);
+}
 
-static inline void *mfn_to_virt_kern(mfn_t mfn) { return paddr_to_virt_kern(mfn << PAGE_SHIFT); }
-static inline void *mfn_to_virt_user(mfn_t mfn) { return paddr_to_virt_user(mfn << PAGE_SHIFT); }
-static inline void *mfn_to_virt(mfn_t mfn)      { return paddr_to_virt(mfn << PAGE_SHIFT);      }
+static inline void *mfn_to_virt_kern(mfn_t mfn) {
+    return paddr_to_virt_kern(mfn << PAGE_SHIFT);
+}
+static inline void *mfn_to_virt_user(mfn_t mfn) {
+    return paddr_to_virt_user(mfn << PAGE_SHIFT);
+}
+static inline void *mfn_to_virt(mfn_t mfn) { return paddr_to_virt(mfn << PAGE_SHIFT); }
 
 #define IS_ADDR_SPACE_VA(va, as) ((_ul(va) & (as)) == (as))
 

--- a/include/pagetable.h
+++ b/include/pagetable.h
@@ -35,20 +35,21 @@ typedef uint64_t pgentry_t;
 union pte {
     pgentry_t entry;
     struct __packed {
-        unsigned int flags:12;
-        unsigned long :47;
-        unsigned int flags_top:5;
+        unsigned int flags : 12;
+        unsigned long : 47;
+        unsigned int flags_top : 5;
     };
     struct __packed {
-        unsigned long paddr:52;
-        unsigned int :12;
+        unsigned long paddr : 52;
+        unsigned int : 12;
     };
     struct __packed {
-        unsigned int P:1, RW:1, US:1, PWT:1, PCD:1, A:1, D:1, PAT:1, G:1;
-        unsigned int IGN0:3;
-        unsigned long mfn:40;
-        unsigned int IGN1:7;
-        unsigned int PKE: 4, NX:1;
+        unsigned int P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, D : 1, PAT : 1,
+            G : 1;
+        unsigned int  IGN0 : 3;
+        unsigned long mfn : 40;
+        unsigned int  IGN1 : 7;
+        unsigned int  PKE : 4, NX : 1;
     };
 };
 typedef union pte pte_t;
@@ -56,19 +57,19 @@ typedef union pte pte_t;
 union pde {
     pgentry_t entry;
     struct __packed {
-        unsigned int flags:12;
-        unsigned long :51;
-        unsigned int flags_top:1;
+        unsigned int flags : 12;
+        unsigned long : 51;
+        unsigned int flags_top : 1;
     };
     struct __packed {
-        unsigned long paddr:52;
-        unsigned int :12;
+        unsigned long paddr : 52;
+        unsigned int : 12;
     };
     struct __packed {
-        unsigned int P:1, RW:1, US:1, PWT:1, PCD:1, A:1, IGN0:1, PS:1;
-        unsigned int IGN1:4;
-        unsigned long mfn:40;
-        unsigned int IGN2:11, NX:1;
+        unsigned int  P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, IGN0 : 1, PS : 1;
+        unsigned int  IGN1 : 4;
+        unsigned long mfn : 40;
+        unsigned int  IGN2 : 11, NX : 1;
     };
 };
 typedef union pde pde_t;
@@ -76,40 +77,40 @@ typedef union pde pde_t;
 union pdpe {
     pgentry_t entry;
     struct __packed {
-        unsigned int flags:12;
-        unsigned long :51;
-        unsigned int flags_top:1;
+        unsigned int flags : 12;
+        unsigned long : 51;
+        unsigned int flags_top : 1;
     };
     struct __packed {
-        unsigned long paddr:52;
-        unsigned int :12;
+        unsigned long paddr : 52;
+        unsigned int : 12;
     };
     struct __packed {
-        unsigned int P:1, RW:1, US:1, PWT:1, PCD:1, A:1, IGN0:1, PS:1;
-        unsigned int IGN1:4;
-        unsigned long mfn:40;
-        unsigned int IGN2:11, NX:1;
+        unsigned int  P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, IGN0 : 1, PS : 1;
+        unsigned int  IGN1 : 4;
+        unsigned long mfn : 40;
+        unsigned int  IGN2 : 11, NX : 1;
     };
 };
 typedef union pdpe pdpe_t;
 
-#if defined (__x86_64__)
+#if defined(__x86_64__)
 union pml4 {
     pgentry_t entry;
     struct __packed {
-        unsigned int flags:12;
-        unsigned long :51;
-        unsigned int flags_top:1;
+        unsigned int flags : 12;
+        unsigned long : 51;
+        unsigned int flags_top : 1;
     };
     struct __packed {
-        unsigned long paddr:52;
-        unsigned int :12;
+        unsigned long paddr : 52;
+        unsigned int : 12;
     };
     struct __packed {
-        unsigned int P:1, RW:1, US:1, PWT:1, PCD:1, A:1, IGN0:1, Z:1;
-        unsigned int IGN1:4;
-        unsigned long mfn:40;
-        unsigned int IGN2:11, NX:1;
+        unsigned int  P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, IGN0 : 1, Z : 1;
+        unsigned int  IGN1 : 4;
+        unsigned long mfn : 40;
+        unsigned int  IGN2 : 11, NX : 1;
     };
 };
 typedef union pml4 pml4_t;
@@ -118,17 +119,17 @@ typedef union pml4 pml4_t;
 union cr3 {
     unsigned long reg;
     struct __packed {
-        unsigned long paddr:52;
-        unsigned int :12;
+        unsigned long paddr : 52;
+        unsigned int : 12;
     };
     struct __packed {
-        unsigned int IGN0:3, PWT:1, PCD:1, IGN1:7;
-        unsigned long mfn:40;
-        unsigned int RSVD:12;
+        unsigned int  IGN0 : 3, PWT : 1, PCD : 1, IGN1 : 7;
+        unsigned long mfn : 40;
+        unsigned int  RSVD : 12;
     };
     struct __packed {
-        unsigned int PCID:12;
-        unsigned long :52;
+        unsigned int PCID : 12;
+        unsigned long : 52;
     };
 };
 typedef union cr3 cr3_t;
@@ -137,37 +138,63 @@ extern cr3_t cr3;
 
 typedef unsigned int pt_index_t;
 
-static inline pt_index_t l1_table_index(const void *va) { return (_ul(va) >> L1_PT_SHIFT) & (L1_PT_ENTRIES - 1); }
-static inline pt_index_t l2_table_index(const void *va) { return (_ul(va) >> L2_PT_SHIFT) & (L2_PT_ENTRIES - 1); }
-static inline pt_index_t l3_table_index(const void *va) { return (_ul(va) >> L3_PT_SHIFT) & (L3_PT_ENTRIES - 1); }
-#if defined (__x86_64__)
-static inline pt_index_t l4_table_index(const void *va) { return (_ul(va) >> L4_PT_SHIFT) & (L4_PT_ENTRIES - 1); }
+static inline pt_index_t l1_table_index(const void *va) {
+    return (_ul(va) >> L1_PT_SHIFT) & (L1_PT_ENTRIES - 1);
+}
+static inline pt_index_t l2_table_index(const void *va) {
+    return (_ul(va) >> L2_PT_SHIFT) & (L2_PT_ENTRIES - 1);
+}
+static inline pt_index_t l3_table_index(const void *va) {
+    return (_ul(va) >> L3_PT_SHIFT) & (L3_PT_ENTRIES - 1);
+}
+#if defined(__x86_64__)
+static inline pt_index_t l4_table_index(const void *va) {
+    return (_ul(va) >> L4_PT_SHIFT) & (L4_PT_ENTRIES - 1);
+}
 #endif
 
-static inline unsigned long l1_index_to_virt(pt_index_t idx) { return _ul(idx) << L1_PT_SHIFT; }
-static inline unsigned long l2_index_to_virt(pt_index_t idx) { return _ul(idx) << L2_PT_SHIFT; }
-static inline unsigned long l3_index_to_virt(pt_index_t idx) { return _ul(idx) << L3_PT_SHIFT; }
-#if defined (__x86_64__)
-static inline unsigned long l4_index_to_virt(pt_index_t idx) { return _ul(idx) << L4_PT_SHIFT; }
+static inline unsigned long l1_index_to_virt(pt_index_t idx) {
+    return _ul(idx) << L1_PT_SHIFT;
+}
+static inline unsigned long l2_index_to_virt(pt_index_t idx) {
+    return _ul(idx) << L2_PT_SHIFT;
+}
+static inline unsigned long l3_index_to_virt(pt_index_t idx) {
+    return _ul(idx) << L3_PT_SHIFT;
+}
+#if defined(__x86_64__)
+static inline unsigned long l4_index_to_virt(pt_index_t idx) {
+    return _ul(idx) << L4_PT_SHIFT;
+}
 #endif
 
-static inline void *virt_from_index(pt_index_t l4, pt_index_t l3, pt_index_t l2, pt_index_t l1) {
-    return _ptr(l4_index_to_virt(l4) | l3_index_to_virt(l3) | l2_index_to_virt(l2) | l1_index_to_virt(l1));
+static inline void *virt_from_index(pt_index_t l4, pt_index_t l3, pt_index_t l2,
+                                    pt_index_t l1) {
+    return _ptr(l4_index_to_virt(l4) | l3_index_to_virt(l3) | l2_index_to_virt(l2) |
+                l1_index_to_virt(l1));
 }
 
-#if defined (__x86_64__)
-static inline pml4_t *l4_table_entry(pml4_t *tab, const void *va) { return &tab[l4_table_index(va)]; }
+#if defined(__x86_64__)
+static inline pml4_t *l4_table_entry(pml4_t *tab, const void *va) {
+    return &tab[l4_table_index(va)];
+}
 #endif
-static inline pdpe_t *l3_table_entry(pdpe_t *tab, const void *va) { return &tab[l3_table_index(va)]; }
-static inline pde_t  *l2_table_entry(pde_t *tab, const void *va)  { return &tab[l2_table_index(va)]; }
-static inline pte_t  *l1_table_entry(pte_t *tab, const void *va)  { return &tab[l1_table_index(va)]; }
+static inline pdpe_t *l3_table_entry(pdpe_t *tab, const void *va) {
+    return &tab[l3_table_index(va)];
+}
+static inline pde_t *l2_table_entry(pde_t *tab, const void *va) {
+    return &tab[l2_table_index(va)];
+}
+static inline pte_t *l1_table_entry(pte_t *tab, const void *va) {
+    return &tab[l1_table_index(va)];
+}
 
 static inline pgentry_t pgentry_from_paddr(paddr_t pa, unsigned long flags) {
-    return (pgentry_t) ((pa & ~(PADDR_MASK & PAGE_MASK)) | (flags & _PAGE_ALL_FLAGS));
+    return (pgentry_t)((pa & ~(PADDR_MASK & PAGE_MASK)) | (flags & _PAGE_ALL_FLAGS));
 }
 
 static inline paddr_t paddr_from_pgentry(pgentry_t pgentry) {
-    return (paddr_t) (pgentry & ~PADDR_MASK) & PAGE_MASK;
+    return (paddr_t)(pgentry & ~PADDR_MASK) & PAGE_MASK;
 }
 
 static inline pgentry_t pgentry_from_mfn(mfn_t mfn, unsigned long flags) {
@@ -182,20 +209,16 @@ static inline pgentry_t pgentry_from_virt(const void *va, unsigned long flags) {
     return pgentry_from_paddr(virt_to_paddr(va), flags);
 }
 
-#if defined (__x86_64__)
-static inline pml4_t *get_l4_table(void) {
-    return paddr_to_virt_kern(read_cr3());
-}
+#if defined(__x86_64__)
+static inline pml4_t *get_l4_table(void) { return paddr_to_virt_kern(read_cr3()); }
 
 static inline pdpe_t *get_l3_table(const void *va) {
     pml4_t *l3e = l4_table_entry(get_l4_table(), va);
 
     return mfn_invalid(l3e->mfn) ? NULL : mfn_to_virt_kern(l3e->mfn);
 }
-#elif defined (__i386__)
-static inline pdpe_t *get_l3_table(void) {
-    return paddr_to_virt_kern(read_cr3());
-}
+#elif defined(__i386__)
+static inline pdpe_t *get_l3_table(void) { return paddr_to_virt_kern(read_cr3()); }
 #endif
 
 static inline pde_t *get_l2_table(const void *va) {
@@ -218,12 +241,12 @@ static inline void set_pgentry(pgentry_t *e, mfn_t mfn, unsigned long flags) {
 
 /* External declarations */
 
-extern pte_t l1_pt_entries[L1_PT_ENTRIES];
-extern pde_t l2_pt_entries[L2_PT_ENTRIES];
+extern pte_t  l1_pt_entries[L1_PT_ENTRIES];
+extern pde_t  l2_pt_entries[L2_PT_ENTRIES];
 extern pdpe_t l3_pt_entries[L3_PT_ENTRIES];
-#if defined (__x86_64__)
+#if defined(__x86_64__)
 extern pml4_t l4_pt_entries[L4_PT_ENTRIES];
-#elif defined (__i386__)
+#elif defined(__i386__)
 #endif
 
 extern void init_pagetables(void);

--- a/include/percpu.h
+++ b/include/percpu.h
@@ -31,14 +31,15 @@
 #include <page.h>
 
 struct percpu {
-    list_head_t list;
-    unsigned int id:8, apic_id:8, enabled:1, bsp:1, family:4, model:4, stepping:4;
+    list_head_t  list;
+    unsigned int id : 8, apic_id : 8, enabled : 1, bsp : 1, family : 4, model : 4,
+        stepping : 4;
 
     idt_entry_t *idt __aligned(16);
-    idt_ptr_t idt_ptr;
+    idt_ptr_t        idt_ptr;
 
     gdt_desc_t gdt[NR_GDT_ENTRIES] __aligned(16);
-    gdt_ptr_t gdt_ptr;
+    gdt_ptr_t  gdt_ptr;
 
     x86_tss_t tss __aligned(16);
 #if defined(__i386__)
@@ -46,13 +47,13 @@ struct percpu {
 #endif
 
     unsigned long ret2kern_sp;
-    void *user_stack;
+    void *        user_stack;
 } __aligned(PAGE_SIZE);
 typedef struct percpu percpu_t;
 
 /* External declarations */
 
-extern void init_percpu(void);
+extern void      init_percpu(void);
 extern percpu_t *get_percpu_page(unsigned int cpu);
 
 #endif /* KTF_PERCPU_H */

--- a/include/processor.h
+++ b/include/processor.h
@@ -31,156 +31,136 @@
 /*
  * EFLAGS bits.
  */
-#define X86_EFLAGS_CF      0x00000001 /* Carry Flag                */
-#define X86_EFLAGS_MBS     0x00000002 /* Resvd bit                 */
-#define X86_EFLAGS_PF      0x00000004 /* Parity Flag               */
-#define X86_EFLAGS_AF      0x00000010 /* Auxillary carry Flag      */
-#define X86_EFLAGS_ZF      0x00000040 /* Zero Flag                 */
-#define X86_EFLAGS_SF      0x00000080 /* Sign Flag                 */
-#define X86_EFLAGS_TF      0x00000100 /* Trap Flag                 */
-#define X86_EFLAGS_IF      0x00000200 /* Interrupt Flag            */
-#define X86_EFLAGS_DF      0x00000400 /* Direction Flag            */
-#define X86_EFLAGS_OF      0x00000800 /* Overflow Flag             */
-#define X86_EFLAGS_IOPL    0x00003000 /* IOPL mask                 */
-#define X86_EFLAGS_NT      0x00004000 /* Nested Task               */
-#define X86_EFLAGS_RF      0x00010000 /* Resume Flag               */
-#define X86_EFLAGS_VM      0x00020000 /* Virtual Mode              */
-#define X86_EFLAGS_AC      0x00040000 /* Alignment Check           */
-#define X86_EFLAGS_VIF     0x00080000 /* Virtual Interrupt Flag    */
-#define X86_EFLAGS_VIP     0x00100000 /* Virtual Interrupt Pending */
-#define X86_EFLAGS_ID      0x00200000 /* CPUID detection flag      */
+#define X86_EFLAGS_CF   0x00000001 /* Carry Flag                */
+#define X86_EFLAGS_MBS  0x00000002 /* Resvd bit                 */
+#define X86_EFLAGS_PF   0x00000004 /* Parity Flag               */
+#define X86_EFLAGS_AF   0x00000010 /* Auxillary carry Flag      */
+#define X86_EFLAGS_ZF   0x00000040 /* Zero Flag                 */
+#define X86_EFLAGS_SF   0x00000080 /* Sign Flag                 */
+#define X86_EFLAGS_TF   0x00000100 /* Trap Flag                 */
+#define X86_EFLAGS_IF   0x00000200 /* Interrupt Flag            */
+#define X86_EFLAGS_DF   0x00000400 /* Direction Flag            */
+#define X86_EFLAGS_OF   0x00000800 /* Overflow Flag             */
+#define X86_EFLAGS_IOPL 0x00003000 /* IOPL mask                 */
+#define X86_EFLAGS_NT   0x00004000 /* Nested Task               */
+#define X86_EFLAGS_RF   0x00010000 /* Resume Flag               */
+#define X86_EFLAGS_VM   0x00020000 /* Virtual Mode              */
+#define X86_EFLAGS_AC   0x00040000 /* Alignment Check           */
+#define X86_EFLAGS_VIF  0x00080000 /* Virtual Interrupt Flag    */
+#define X86_EFLAGS_VIP  0x00100000 /* Virtual Interrupt Pending */
+#define X86_EFLAGS_ID   0x00200000 /* CPUID detection flag      */
 
 /*
  * CPU flags in CR0.
  */
-#define X86_CR0_PE         0x00000001 /* Enable Protected Mode    (RW) */
-#define X86_CR0_MP         0x00000002 /* Monitor Coprocessor      (RW) */
-#define X86_CR0_EM         0x00000004 /* Require FPU Emulation    (RO) */
-#define X86_CR0_TS         0x00000008 /* Task Switched            (RW) */
-#define X86_CR0_ET         0x00000010 /* Extension type           (RO) */
-#define X86_CR0_NE         0x00000020 /* Numeric Error Reporting  (RW) */
-#define X86_CR0_WP         0x00010000 /* Supervisor Write Protect (RW) */
-#define X86_CR0_AM         0x00040000 /* Alignment Checking       (RW) */
-#define X86_CR0_NW         0x20000000 /* Not Write-Through        (RW) */
-#define X86_CR0_CD         0x40000000 /* Cache Disable            (RW) */
-#define X86_CR0_PG         0x80000000 /* Paging                   (RW) */
+#define X86_CR0_PE 0x00000001 /* Enable Protected Mode    (RW) */
+#define X86_CR0_MP 0x00000002 /* Monitor Coprocessor      (RW) */
+#define X86_CR0_EM 0x00000004 /* Require FPU Emulation    (RO) */
+#define X86_CR0_TS 0x00000008 /* Task Switched            (RW) */
+#define X86_CR0_ET 0x00000010 /* Extension type           (RO) */
+#define X86_CR0_NE 0x00000020 /* Numeric Error Reporting  (RW) */
+#define X86_CR0_WP 0x00010000 /* Supervisor Write Protect (RW) */
+#define X86_CR0_AM 0x00040000 /* Alignment Checking       (RW) */
+#define X86_CR0_NW 0x20000000 /* Not Write-Through        (RW) */
+#define X86_CR0_CD 0x40000000 /* Cache Disable            (RW) */
+#define X86_CR0_PG 0x80000000 /* Paging                   (RW) */
 
 /*
  * CPU features in CR4.
  */
-#define X86_CR4_VME        0x00000001  /* VM86 extensions                */
-#define X86_CR4_PVI        0x00000002  /* Virtual interrupts flag        */
-#define X86_CR4_TSD        0x00000004  /* Disable time stamp at ipl 3    */
-#define X86_CR4_DE         0x00000008  /* Debugging extensions           */
-#define X86_CR4_PSE        0x00000010  /* Page size extensions           */
-#define X86_CR4_PAE        0x00000020  /* Physical address extensions    */
-#define X86_CR4_MCE        0x00000040  /* Machine check                  */
-#define X86_CR4_PGE        0x00000080  /* Global pages                   */
-#define X86_CR4_PCE        0x00000100  /* Performance counters at ipl 3  */
-#define X86_CR4_OSFXSR     0x00000200  /* Fast FPU save and restore      */
-#define X86_CR4_OSXMMEXCPT 0x00000400  /* Unmasked SSE exceptions        */
-#define X86_CR4_UMIP       0x00000800  /* UMIP                           */
-#define X86_CR4_VMXE       0x00002000  /* VMX                            */
-#define X86_CR4_SMXE       0x00004000  /* SMX                            */
-#define X86_CR4_FSGSBASE   0x00010000  /* {rd,wr}{fs,gs}base             */
-#define X86_CR4_PCIDE      0x00020000  /* PCID                           */
-#define X86_CR4_OSXSAVE    0x00040000  /* XSAVE/XRSTOR                   */
-#define X86_CR4_SMEP       0x00100000  /* SMEP                           */
-#define X86_CR4_SMAP       0x00200000  /* SMAP                           */
+#define X86_CR4_VME        0x00000001 /* VM86 extensions                */
+#define X86_CR4_PVI        0x00000002 /* Virtual interrupts flag        */
+#define X86_CR4_TSD        0x00000004 /* Disable time stamp at ipl 3    */
+#define X86_CR4_DE         0x00000008 /* Debugging extensions           */
+#define X86_CR4_PSE        0x00000010 /* Page size extensions           */
+#define X86_CR4_PAE        0x00000020 /* Physical address extensions    */
+#define X86_CR4_MCE        0x00000040 /* Machine check                  */
+#define X86_CR4_PGE        0x00000080 /* Global pages                   */
+#define X86_CR4_PCE        0x00000100 /* Performance counters at ipl 3  */
+#define X86_CR4_OSFXSR     0x00000200 /* Fast FPU save and restore      */
+#define X86_CR4_OSXMMEXCPT 0x00000400 /* Unmasked SSE exceptions        */
+#define X86_CR4_UMIP       0x00000800 /* UMIP                           */
+#define X86_CR4_VMXE       0x00002000 /* VMX                            */
+#define X86_CR4_SMXE       0x00004000 /* SMX                            */
+#define X86_CR4_FSGSBASE   0x00010000 /* {rd,wr}{fs,gs}base             */
+#define X86_CR4_PCIDE      0x00020000 /* PCID                           */
+#define X86_CR4_OSXSAVE    0x00040000 /* XSAVE/XRSTOR                   */
+#define X86_CR4_SMEP       0x00100000 /* SMEP                           */
+#define X86_CR4_SMAP       0x00200000 /* SMAP                           */
 
 /*
  * Model Specific Registers (MSR)
  */
-#define MSR_APIC_BASE      0x0000001B
-#define MSR_X2APIC_REGS    0x00000800
+#define MSR_APIC_BASE   0x0000001B
+#define MSR_X2APIC_REGS 0x00000800
 
-#define MSR_EFER           0xc0000080      /* Extended Feature Enable Register */
-#define EFER_SCE           (_U64(1) <<  0) /* SYSCALL Enable */
-#define EFER_LME           (_U64(1) <<  8) /* Long Mode Enable */
-#define EFER_LMA           (_U64(1) << 10) /* Long Mode Active */
-#define EFER_NXE           (_U64(1) << 11) /* No Execute Enable */
-#define EFER_SVME          (_U64(1) << 12) /* Secure Virtual Machine Enable */
-#define EFER_LMSLE         (_U64(1) << 13) /* Long Mode Segment Limit Enable */
-#define EFER_FFXSR         (_U64(1) << 14) /* Fast FXSAVE/FXRSTOR */
-#define EFER_TCE           (_U64(1) << 15) /* Translation Cache Extension */
+#define MSR_EFER   0xc0000080      /* Extended Feature Enable Register */
+#define EFER_SCE   (_U64(1) << 0)  /* SYSCALL Enable */
+#define EFER_LME   (_U64(1) << 8)  /* Long Mode Enable */
+#define EFER_LMA   (_U64(1) << 10) /* Long Mode Active */
+#define EFER_NXE   (_U64(1) << 11) /* No Execute Enable */
+#define EFER_SVME  (_U64(1) << 12) /* Secure Virtual Machine Enable */
+#define EFER_LMSLE (_U64(1) << 13) /* Long Mode Segment Limit Enable */
+#define EFER_FFXSR (_U64(1) << 14) /* Fast FXSAVE/FXRSTOR */
+#define EFER_TCE   (_U64(1) << 15) /* Translation Cache Extension */
 
-#define MSR_STAR           0xc0000081
-#define MSR_LSTAR          0xc0000082
-#define MSR_CSTAR          0xc0000083
-#define MSR_FMASK          0xc0000084
+#define MSR_STAR  0xc0000081
+#define MSR_LSTAR 0xc0000082
+#define MSR_CSTAR 0xc0000083
+#define MSR_FMASK 0xc0000084
 
 #define MSR_FS_BASE        0xc0000100
 #define MSR_GS_BASE        0xc0000101
 #define MSR_SHADOW_GS_BASE 0xc0000102
 
-#define MSR_TSC_AUX        0xc0000103
+#define MSR_TSC_AUX 0xc0000103
 
 /*
  * Exception mnemonics.
  */
-#define X86_EX_DE       0 /* Divide Error. */
-#define X86_EX_DB       1 /* Debug Exception. */
-#define X86_EX_NMI      2 /* NMI. */
-#define X86_EX_BP       3 /* Breakpoint. */
-#define X86_EX_OF       4 /* Overflow. */
-#define X86_EX_BR       5 /* BOUND Range. */
-#define X86_EX_UD       6 /* Invalid Opcode. */
-#define X86_EX_NM       7 /* Device Not Available. */
-#define X86_EX_DF       8 /* Double Fault. */
-#define X86_EX_CS       9 /* Coprocessor Segment Overrun. */
-#define X86_EX_TS      10 /* Invalid TSS. */
-#define X86_EX_NP      11 /* Segment Not Present. */
-#define X86_EX_SS      12 /* Stack-Segment Fault. */
-#define X86_EX_GP      13 /* General Porection Fault. */
-#define X86_EX_PF      14 /* Page Fault. */
-#define X86_EX_SPV     15 /* PIC Spurious Interrupt Vector. */
-#define X86_EX_MF      16 /* Maths fault (x87 FPU). */
-#define X86_EX_AC      17 /* Alignment Check. */
-#define X86_EX_MC      18 /* Machine Check. */
-#define X86_EX_XM      19 /* SIMD Exception. */
-#define X86_EX_VE      20 /* Virtualisation Exception. */
-#define X86_EX_SE      30 /* Security Exception. */
+#define X86_EX_DE  0  /* Divide Error. */
+#define X86_EX_DB  1  /* Debug Exception. */
+#define X86_EX_NMI 2  /* NMI. */
+#define X86_EX_BP  3  /* Breakpoint. */
+#define X86_EX_OF  4  /* Overflow. */
+#define X86_EX_BR  5  /* BOUND Range. */
+#define X86_EX_UD  6  /* Invalid Opcode. */
+#define X86_EX_NM  7  /* Device Not Available. */
+#define X86_EX_DF  8  /* Double Fault. */
+#define X86_EX_CS  9  /* Coprocessor Segment Overrun. */
+#define X86_EX_TS  10 /* Invalid TSS. */
+#define X86_EX_NP  11 /* Segment Not Present. */
+#define X86_EX_SS  12 /* Stack-Segment Fault. */
+#define X86_EX_GP  13 /* General Porection Fault. */
+#define X86_EX_PF  14 /* Page Fault. */
+#define X86_EX_SPV 15 /* PIC Spurious Interrupt Vector. */
+#define X86_EX_MF  16 /* Maths fault (x87 FPU). */
+#define X86_EX_AC  17 /* Alignment Check. */
+#define X86_EX_MC  18 /* Machine Check. */
+#define X86_EX_XM  19 /* SIMD Exception. */
+#define X86_EX_VE  20 /* Virtualisation Exception. */
+#define X86_EX_SE  30 /* Security Exception. */
 
 #define X86_EX_BIT(exception) (1 << (exception))
 
-#define X86_EX_FAULT_BITMASK ( \
-    X86_EX_BIT(X86_EX_DE) | \
-    X86_EX_BIT(X86_EX_BR) | \
-    X86_EX_BIT(X86_EX_UD) | \
-    X86_EX_BIT(X86_EX_NM) | \
-    X86_EX_BIT(X86_EX_CS) | \
-    X86_EX_BIT(X86_EX_TS) | \
-    X86_EX_BIT(X86_EX_NP) | \
-    X86_EX_BIT(X86_EX_SS) | \
-    X86_EX_BIT(X86_EX_GP) | \
-    X86_EX_BIT(X86_EX_PF) | \
-    X86_EX_BIT(X86_EX_MF) | \
-    X86_EX_BIT(X86_EX_AC) | \
-    X86_EX_BIT(X86_EX_XM) | \
-    X86_EX_BIT(X86_EX_VE))
+#define X86_EX_FAULT_BITMASK                                                             \
+    (X86_EX_BIT(X86_EX_DE) | X86_EX_BIT(X86_EX_BR) | X86_EX_BIT(X86_EX_UD) |             \
+     X86_EX_BIT(X86_EX_NM) | X86_EX_BIT(X86_EX_CS) | X86_EX_BIT(X86_EX_TS) |             \
+     X86_EX_BIT(X86_EX_NP) | X86_EX_BIT(X86_EX_SS) | X86_EX_BIT(X86_EX_GP) |             \
+     X86_EX_BIT(X86_EX_PF) | X86_EX_BIT(X86_EX_MF) | X86_EX_BIT(X86_EX_AC) |             \
+     X86_EX_BIT(X86_EX_XM) | X86_EX_BIT(X86_EX_VE))
 
-#define X86_EX_TRAP_BITMASK ( \
-    X86_EX_BIT(X86_EX_DB) | \
-    X86_EX_BIT(X86_EX_BP) | \
-    X86_EX_BIT(X86_EX_OF))
+#define X86_EX_TRAP_BITMASK                                                              \
+    (X86_EX_BIT(X86_EX_DB) | X86_EX_BIT(X86_EX_BP) | X86_EX_BIT(X86_EX_OF))
 
-#define X86_EX_INTR_BITMASK ( \
-    X86_EX_BIT(X86_EX_NMI) | \
-    X86_EX_BIT(X86_EX_SPV))
+#define X86_EX_INTR_BITMASK (X86_EX_BIT(X86_EX_NMI) | X86_EX_BIT(X86_EX_SPV))
 
-#define X86_EX_ABORT_BITMASK ( \
-    X86_EX_BIT(X86_EX_DF) | \
-    X86_EX_BIT(X86_EX_MC))
+#define X86_EX_ABORT_BITMASK (X86_EX_BIT(X86_EX_DF) | X86_EX_BIT(X86_EX_MC))
 
-#define X86_EX_HAS_ERROR_CODE ( \
-    X86_EX_BIT(X86_EX_DF) | \
-    X86_EX_BIT(X86_EX_TS) | \
-    X86_EX_BIT(X86_EX_NP) | \
-    X86_EX_BIT(X86_EX_SS) | \
-    X86_EX_BIT(X86_EX_GP) | \
-    X86_EX_BIT(X86_EX_PF) | \
-    X86_EX_BIT(X86_EX_AC) | \
-    X86_EX_BIT(X86_EX_SE))
+#define X86_EX_HAS_ERROR_CODE                                                            \
+    (X86_EX_BIT(X86_EX_DF) | X86_EX_BIT(X86_EX_TS) | X86_EX_BIT(X86_EX_NP) |             \
+     X86_EX_BIT(X86_EX_SS) | X86_EX_BIT(X86_EX_GP) | X86_EX_BIT(X86_EX_PF) |             \
+     X86_EX_BIT(X86_EX_AC) | X86_EX_BIT(X86_EX_SE))
 
 #define X86_EX_PFEC_PRESENT 0x01
 #define X86_EX_PFEC_WRITE   0x02
@@ -197,10 +177,10 @@
 union x86_ex_error_code {
     uint32_t error_code;
     struct __packed {
-        unsigned int E:1, TLB:2, index:13, rsvd_sel:16;
+        unsigned int E : 1, TLB : 2, index : 13, rsvd_sel : 16;
     };
     struct __packed {
-        unsigned int P:1, W:1, U:1, R:1, I:1, rsvd_pfec:27;
+        unsigned int P : 1, W : 1, U : 1, R : 1, I : 1, rsvd_pfec : 27;
     };
 };
 typedef union x86_ex_error_code x86_ex_error_code_t;
@@ -259,10 +239,10 @@ struct cpu_regs {
 
     /* Hardware exception */
     x86_reg_t _ASM_IP;
-    uint16_t cs, _pad_cs[3];
+    uint16_t  cs, _pad_cs[3];
     x86_reg_t _ASM_FLAGS;
     x86_reg_t _ASM_SP;
-    uint16_t ss, _pad_ss[3];
+    uint16_t  ss, _pad_ss[3];
 };
 typedef struct cpu_regs cpu_regs_t;
 

--- a/include/sched.h
+++ b/include/sched.h
@@ -27,8 +27,8 @@
 
 #include <ktf.h>
 #include <lib.h>
-#include <page.h>
 #include <list.h>
+#include <page.h>
 
 typedef void (*task_func_t)(void *this, void *arg);
 
@@ -46,14 +46,14 @@ typedef unsigned int tid_t;
 struct task {
     list_head_t list;
 
-    tid_t id;
+    tid_t        id;
     task_state_t state;
 
     unsigned int cpu;
 
     const char *name;
     task_func_t func;
-    void *arg;
+    void *      arg;
 
     unsigned long result;
 } __aligned(PAGE_SIZE);
@@ -61,13 +61,13 @@ typedef struct task task_t;
 
 /* External declarations */
 
-extern void init_tasks(void);
+extern void    init_tasks(void);
 extern task_t *get_task_by_id(tid_t id);
 extern task_t *get_task_by_name(const char *name);
 extern task_t *get_task_for_cpu(unsigned int cpu);
 extern task_t *new_task(const char *name, task_func_t func, void *arg);
-extern void schedule_task(task_t *task, unsigned int cpu);
-extern void run_tasks(unsigned int cpu);
-extern void wait_for_all_tasks(void);
+extern void    schedule_task(task_t *task, unsigned int cpu);
+extern void    run_tasks(unsigned int cpu);
+extern void    wait_for_all_tasks(void);
 
 #endif /* KTF_SCHED_H */

--- a/include/segment.h
+++ b/include/segment.h
@@ -38,10 +38,10 @@
 #define GDT_USER_DS32 0x5
 #define GDT_USER_CS64 0x6
 
-#define GDT_TSS       0x7
-#define GDT_TSS_DF    0x8
+#define GDT_TSS    0x7
+#define GDT_TSS_DF 0x8
 
-#define GDT_PERCPU    0x9
+#define GDT_PERCPU 0x9
 
 #define NR_GDT_ENTRIES 10
 
@@ -68,31 +68,29 @@
 #define __USER_DS __USER_DS64
 #endif
 
-#define _GDT_ENTRY(flags, base, limit) ( \
-         (((base)  & _U64(0xff000000)) << (56-24)) | \
-         (((flags) & _U64(0x0000f0ff)) << 40)      | \
-         (((limit) & _U64(0x000f0000)) << (48-16)) | \
-         (((base)  & _U64(0x00ffffff)) << 16)      | \
-         (((limit) & _U64(0x0000ffff))))
+#define _GDT_ENTRY(flags, base, limit)                                                   \
+    ((((base) &_U64(0xff000000)) << (56 - 24)) | (((flags) &_U64(0x0000f0ff)) << 40) |   \
+     (((limit) &_U64(0x000f0000)) << (48 - 16)) | (((base) &_U64(0x00ffffff)) << 16) |   \
+     (((limit) &_U64(0x0000ffff))))
 
-#define DESC_FLAG_GR     0x8000 /* Granularity of limit (0 = 1, 1 = 4K) */
-#define DESC_FLAG_SZ     0x4000 /* Default operand size (0 = 16bit, 1 = 32bit) */
-#define DESC_FLAG_B      0x4000 /* 'Big' flag. */
-#define DESC_FLAG_L      0x2000 /* Long segment? (1 = 64bit) */
-#define DESC_FLAG_AVL    0x1000 /* Available for software use */
-#define DESC_FLAG_P      0x0080 /* Present? */
-#define DESC_FLAG_DPL3   0x0060 /* Descriptor privilege level 3 */
-#define DESC_FLAG_DPL2   0x0040 /* Descriptor privilege level 2 */
-#define DESC_FLAG_DPL1   0x0020 /* Descriptor privilege level 1 */
-#define DESC_FLAG_DPL0   0x0000 /* Descriptor privilege level 0 */
-#define DESC_FLAG_S      0x0010 /* !System desc (0 = system, 1 = user) */
-#define DESC_FLAG_CODE   0x0008 /* Type (0 = data, 1 = code)    */
-#define DESC_FLAG_DATA   0x0000 /* Type (0 = data, 1 = code)    */
-#define DESC_FLAG_C      0x0004 /* Conforming? (0 = non, 1 = conforming) */
-#define DESC_FLAG_D      0x0004 /* Expand-down? (0 = normal, 1 = expand-down) */
-#define DESC_FLAG_R      0x0002 /* Readable? (0 = XO seg, 1 = RX seg) */
-#define DESC_FLAG_W      0x0002 /* Writable? (0 = RO seg, 1 = RW seg) */
-#define DESC_FLAG_A      0x0001 /* Accessed? (set by hardware) */
+#define DESC_FLAG_GR   0x8000 /* Granularity of limit (0 = 1, 1 = 4K) */
+#define DESC_FLAG_SZ   0x4000 /* Default operand size (0 = 16bit, 1 = 32bit) */
+#define DESC_FLAG_B    0x4000 /* 'Big' flag. */
+#define DESC_FLAG_L    0x2000 /* Long segment? (1 = 64bit) */
+#define DESC_FLAG_AVL  0x1000 /* Available for software use */
+#define DESC_FLAG_P    0x0080 /* Present? */
+#define DESC_FLAG_DPL3 0x0060 /* Descriptor privilege level 3 */
+#define DESC_FLAG_DPL2 0x0040 /* Descriptor privilege level 2 */
+#define DESC_FLAG_DPL1 0x0020 /* Descriptor privilege level 1 */
+#define DESC_FLAG_DPL0 0x0000 /* Descriptor privilege level 0 */
+#define DESC_FLAG_S    0x0010 /* !System desc (0 = system, 1 = user) */
+#define DESC_FLAG_CODE 0x0008 /* Type (0 = data, 1 = code)    */
+#define DESC_FLAG_DATA 0x0000 /* Type (0 = data, 1 = code)    */
+#define DESC_FLAG_C    0x0004 /* Conforming? (0 = non, 1 = conforming) */
+#define DESC_FLAG_D    0x0004 /* Expand-down? (0 = normal, 1 = expand-down) */
+#define DESC_FLAG_R    0x0002 /* Readable? (0 = XO seg, 1 = RX seg) */
+#define DESC_FLAG_W    0x0002 /* Writable? (0 = RO seg, 1 = RW seg) */
+#define DESC_FLAG_A    0x0001 /* Accessed? (set by hardware) */
 
 #define DESC_FLAGS(...) (TOKEN_OR(DESC_FLAG_, ##__VA_ARGS__))
 
@@ -109,17 +107,16 @@ struct __packed x86_segment_desc {
         struct __packed {
             uint16_t limit_lo;
             uint16_t base_lo;
-            uint8_t base_mi;
+            uint8_t  base_mi;
             struct __packed {
-                uint8_t A:1, RW:1, DC:1, E:1, S:1, DPL:2, P:1;
+                uint8_t A : 1, RW : 1, DC : 1, E : 1, S : 1, DPL : 2, P : 1;
             };
             struct __packed {
-                uint8_t limit_hi:4;
-                uint8_t :1, L:1, SZ:1, GR:1;
-	    };
+                uint8_t limit_hi : 4;
+                uint8_t : 1, L : 1, SZ : 1, GR : 1;
+            };
             uint8_t base_hi;
-	};
-
+        };
     };
 };
 typedef struct x86_segment_desc x86_segment_desc_t;
@@ -127,7 +124,7 @@ typedef struct x86_segment_desc x86_segment_desc_t;
 typedef x86_segment_desc_t gdt_desc_t;
 
 static inline void set_desc_base(x86_segment_desc_t *desc, unsigned long base) {
-    desc[0].base_lo =  (base & _ul(0x0000ffff));
+    desc[0].base_lo = (base & _ul(0x0000ffff));
     desc[0].base_mi = ((base & _ul(0x00ff0000)) >> 16);
     desc[0].base_hi = ((base & _ul(0xff000000)) >> 24);
 #if defined(__x86_64__)
@@ -157,11 +154,11 @@ struct __packed x86_gate32 {
             uint32_t lo, hi;
         };
         struct {
-            uint16_t offset_lo;
-            uint16_t selector;
-            uint8_t rsvd;
-            unsigned int type:4, s:1, dpl:2, p:1;
-            uint16_t offset_hi;
+            uint16_t     offset_lo;
+            uint16_t     selector;
+            uint8_t      rsvd;
+            unsigned int type : 4, s : 1, dpl : 2, p : 1;
+            uint16_t     offset_hi;
         };
     };
 };
@@ -171,9 +168,8 @@ static inline void set_gate32_offset(struct x86_gate32 *gate, unsigned long offs
     gate->offset_hi = ((offset & _ul(0xffff0000)) >> 16);
 }
 
-static inline void set_gate32(struct x86_gate32 *gate, uint8_t type,
-                              uint16_t selector, unsigned long offset,
-                              uint8_t dpl, bool present) {
+static inline void set_gate32(struct x86_gate32 *gate, uint8_t type, uint16_t selector,
+                              unsigned long offset, uint8_t dpl, bool present) {
     set_gate32_offset(gate, offset);
     gate->type = type;
     gate->selector = selector;
@@ -191,26 +187,26 @@ struct __packed x86_gate64 {
             uint64_t lo, hi;
         };
         struct {
-            uint16_t offset_lo;
-            uint16_t selector;
-            unsigned int ist:3, rsvd0:5;
-            unsigned int type:4, s:1, dpl:2, p:1;
-            uint16_t offset_mi;
-            uint32_t offset_hi;
-            uint32_t rsvd1;
+            uint16_t     offset_lo;
+            uint16_t     selector;
+            unsigned int ist : 3, rsvd0 : 5;
+            unsigned int type : 4, s : 1, dpl : 2, p : 1;
+            uint16_t     offset_mi;
+            uint32_t     offset_hi;
+            uint32_t     rsvd1;
         };
     };
 };
 
 static inline void set_gate64_offset(struct x86_gate64 *gate, unsigned long offset) {
-    gate->offset_lo =  (offset & _ul(0x000000000000ffff));
+    gate->offset_lo = (offset & _ul(0x000000000000ffff));
     gate->offset_mi = ((offset & _ul(0x00000000ffff0000)) >> 16);
     gate->offset_hi = ((offset & _ul(0xffffffff00000000)) >> 32);
 }
 
-static inline void set_gate64(struct x86_gate64 *gate, uint8_t type,
-                              uint16_t selector, unsigned long offset,
-                              uint8_t dpl, bool present, uint8_t ist) {
+static inline void set_gate64(struct x86_gate64 *gate, uint8_t type, uint16_t selector,
+                              unsigned long offset, uint8_t dpl, bool present,
+                              uint8_t ist) {
     set_gate64_offset(gate, offset);
     gate->type = type;
     gate->selector = selector;
@@ -221,50 +217,59 @@ static inline void set_gate64(struct x86_gate64 *gate, uint8_t type,
 }
 
 #define GATE_NOT_PRESENT 0x00
-#define GATE_PRESENT 0x01
-#define GATE_DPL0 0x00
-#define GATE_DPL3 0x03
+#define GATE_PRESENT     0x01
+#define GATE_DPL0        0x00
+#define GATE_DPL3        0x03
 
 #define GATE_TYPE_INTR _U32(0xE)
 #define GATE_TYPE_TRAP _U32(0xF)
 #define GATE_TYPE_TASK _U32(0x5)
 
-#define _GATE_ENTRY32(type, selector, offset, dpl, present) { \
-    .offset_lo = ((offset) & _U32(0x0000ffff)),               \
-    .offset_hi = (((offset) & _U32(0xffff0000)) >> 16),       \
-    .selector =  ((selector) & _U32(0xffff)),                 \
-    .rsvd = 0, .s = 0, .type = ((type) & _U32(0xf)),          \
-    .dpl = ((dpl) & _U32(0x3)), .p = ((present) & 0x1) }
+#define _GATE_ENTRY32(type, selector, offset, dpl, present)                              \
+    {                                                                                    \
+        .offset_lo = ((offset) &_U32(0x0000ffff)),                                       \
+        .offset_hi = (((offset) &_U32(0xffff0000)) >> 16),                               \
+        .selector = ((selector) &_U32(0xffff)), .rsvd = 0, .s = 0,                       \
+        .type = ((type) &_U32(0xf)), .dpl = ((dpl) &_U32(0x3)), .p = ((present) &0x1)    \
+    }
 
-#define INTR_GATE32(selector, offset, dpl, present) _GATE_ENTRY32(GATE_TYPE_INTR, selector, offset, dpl, present)
-#define TRAP_GATE32(selector, offset, dpl, present) _GATE_ENTRY32(GATE_TYPE_TRAP, selector, offset, dpl, present)
-#define TASK_GATE32(selector, dpl, present) _GATE_ENTRY32(GATE_TYPE_TASK, selector, _U32(0x0), dpl, present)
+#define INTR_GATE32(selector, offset, dpl, present)                                      \
+    _GATE_ENTRY32(GATE_TYPE_INTR, selector, offset, dpl, present)
+#define TRAP_GATE32(selector, offset, dpl, present)                                      \
+    _GATE_ENTRY32(GATE_TYPE_TRAP, selector, offset, dpl, present)
+#define TASK_GATE32(selector, dpl, present)                                              \
+    _GATE_ENTRY32(GATE_TYPE_TASK, selector, _U32(0x0), dpl, present)
 
-#define _GATE_ENTRY64(_type, _selector, _offset, _dpl, _present) { \
-    .offset_lo = (((_offset) & _U64(0x000000000000ffff))),         \
-    .offset_mi = (((_offset) & _U64(0x00000000ffff0000)) >> 16),   \
-    .offset_hi = (((_offset) & _U64(0xffffffff00000000)) >> 32),   \
-    .selector = ((_selector) & _U32(0xffff)),                      \
-    .rsvd0 = 0, .rsvd1 = 0, .s = 0, .type = ((_type) & _U32(0xf)), \
-    .dpl = ((_dpl) & _U32(0x3)), .p = ((_present) & 0x1) }
+#define _GATE_ENTRY64(_type, _selector, _offset, _dpl, _present)                         \
+    {                                                                                    \
+        .offset_lo = (((_offset) &_U64(0x000000000000ffff))),                            \
+        .offset_mi = (((_offset) &_U64(0x00000000ffff0000)) >> 16),                      \
+        .offset_hi = (((_offset) &_U64(0xffffffff00000000)) >> 32),                      \
+        .selector = ((_selector) &_U32(0xffff)), .rsvd0 = 0, .rsvd1 = 0, .s = 0,         \
+        .type = ((_type) &_U32(0xf)), .dpl = ((_dpl) &_U32(0x3)), .p = ((_present) &0x1) \
+    }
 
-#define INTR_GATE64(selector, offset, dpl, present) _GATE_ENTRY64(GATE_TYPE_INTR, selector, offset, dpl, present)
-#define TRAP_GATE64(selector, offset, dpl, present) _GATE_ENTRY64(GATE_TYPE_TRAPf, selector, offset, dpl, present)
+#define INTR_GATE64(selector, offset, dpl, present)                                      \
+    _GATE_ENTRY64(GATE_TYPE_INTR, selector, offset, dpl, present)
+#define TRAP_GATE64(selector, offset, dpl, present)                                      \
+    _GATE_ENTRY64(GATE_TYPE_TRAPf, selector, offset, dpl, present)
 
 #if defined(__i386__)
 
 typedef struct x86_gate32 task_gate_t;
 typedef struct x86_gate32 idt_entry_t;
 
-#define INTR_GATE(selector, offset, dpl, present) INTR_GATE32(selector, offset, GATE_ ## dpl, GATE_ ## present)
-#define TRAP_GATE(selector, offset, dpl, present) TRAP_FATE32(selector, offset, GATE_ ## dpl, GATE_ ## present)
-#define TASK_GATE(selector, dpl, present) TASK_GATE32(selector, GATE_ ## dpl, GATE_ ## present)
+#define INTR_GATE(selector, offset, dpl, present)                                        \
+    INTR_GATE32(selector, offset, GATE_##dpl, GATE_##present)
+#define TRAP_GATE(selector, offset, dpl, present)                                        \
+    TRAP_FATE32(selector, offset, GATE_##dpl, GATE_##present)
+#define TASK_GATE(selector, dpl, present)                                                \
+    TASK_GATE32(selector, GATE_##dpl, GATE_##present)
 
 #define set_gate_offset(gate, offset) set_gate32_offset((gate), (offset))
 
-static inline void set_intr_gate(struct x86_gate32 *gate,
-                                 uint16_t selector, unsigned long offset,
-                                 uint8_t dpl, bool present) {
+static inline void set_intr_gate(struct x86_gate32 *gate, uint16_t selector,
+                                 unsigned long offset, uint8_t dpl, bool present) {
     set_gate32(gate, GATE_TYPE_INTR, selector, offset, dpl, present);
 }
 
@@ -273,20 +278,22 @@ static inline void set_intr_gate(struct x86_gate32 *gate,
 typedef struct x86_gate64 task_gate_t;
 typedef struct x86_gate64 idt_entry_t;
 
-#define INTR_GATE(selector, offset, dpl, present) INTR_GATE64(selector, offset, GATE_ ## dpl, GATE_ ## present)
-#define TRAP_GATE(selector, offset, dpl, present) TRAP_FATE64(selector, offset, GATE_ ## dpl, GATE_ ## present)
+#define INTR_GATE(selector, offset, dpl, present)                                        \
+    INTR_GATE64(selector, offset, GATE_##dpl, GATE_##present)
+#define TRAP_GATE(selector, offset, dpl, present)                                        \
+    TRAP_FATE64(selector, offset, GATE_##dpl, GATE_##present)
 
 #define set_gate_offset(gate, offset) set_gate64_offset((gate), (offset))
 
-static inline void set_intr_gate(struct x86_gate64 *gate,
-                                 uint16_t selector, unsigned long offset,
-                                 uint8_t dpl, bool present, uint8_t ist) {
+static inline void set_intr_gate(struct x86_gate64 *gate, uint16_t selector,
+                                 unsigned long offset, uint8_t dpl, bool present,
+                                 uint8_t ist) {
     set_gate64(gate, GATE_TYPE_INTR, selector, offset, dpl, present, ist);
 }
 #endif
 
 extern idt_entry_t idt[256];
-extern idt_ptr_t idt_ptr;
+extern idt_ptr_t   idt_ptr;
 #endif /* __ASSEMBLY__ */
 
 #endif /* KTF_SEGMENT_H */

--- a/include/setup.h
+++ b/include/setup.h
@@ -38,7 +38,7 @@ extern io_port_t com_ports[2];
 extern const char *kernel_cmdline;
 
 static inline void get_com_ports(void) {
-    memcpy((void *) com_ports, (void *)(BDA_COM_PORTS_ENTRY), sizeof(com_ports));
+    memcpy((void *) com_ports, (void *) (BDA_COM_PORTS_ENTRY), sizeof(com_ports));
 
     if (com_ports[0] == 0x0)
         com_ports[0] = 0x3f8;

--- a/include/smp/mptables.h
+++ b/include/smp/mptables.h
@@ -33,12 +33,12 @@
 struct mpf {
     uint32_t signature;
     uint32_t mpc_base;
-    uint8_t length;
-    uint8_t spec_rev;
-    uint8_t checksum;
-    uint8_t mpc_type;
-    uint8_t rsvd0:6, imcrp:1;
-    uint8_t rsvd1[3];
+    uint8_t  length;
+    uint8_t  spec_rev;
+    uint8_t  checksum;
+    uint8_t  mpc_type;
+    uint8_t  rsvd0 : 6, imcrp : 1;
+    uint8_t  rsvd1[3];
 } __packed;
 typedef struct mpf mpf_t;
 
@@ -54,94 +54,94 @@ enum mpc_entry_type {
 typedef enum mpc_entry_type mpc_entry_type_t;
 
 struct mpc_hdr {
-    uint32_t signature;
-    uint16_t length;
-    uint8_t spec_rev;
-    uint8_t checksum;
+    uint32_t   signature;
+    uint16_t   length;
+    uint8_t    spec_rev;
+    uint8_t    checksum;
     const char oem_id[8];
     const char product_id[12];
-    uint32_t oem_tlb_ptr;
-    uint16_t oem_tlb_size;
-    uint16_t entry_count;
-    uint32_t lapic_base;
-    uint16_t ext_length;
-    uint8_t ext_checksum;
-    uint8_t rsvd;
+    uint32_t   oem_tlb_ptr;
+    uint16_t   oem_tlb_size;
+    uint16_t   entry_count;
+    uint32_t   lapic_base;
+    uint16_t   ext_length;
+    uint8_t    ext_checksum;
+    uint8_t    rsvd;
 } __packed;
 typedef struct mpc_hdr mpc_hdr_t;
 
 struct mpc_processor_entry {
-   uint8_t type;
-   uint8_t lapic_id;
-   uint8_t lapic_version;
-   struct {
-       uint8_t en:1, bsp:1, rsvd0:6;
-   };
-   struct {
-       uint32_t stepping:4, model:4, family:4, rsvd1:20;
-   };
-   uint32_t feature_flags;
-   uint32_t rsvd2;
-   uint32_t rsvd3;
+    uint8_t type;
+    uint8_t lapic_id;
+    uint8_t lapic_version;
+    struct {
+        uint8_t en : 1, bsp : 1, rsvd0 : 6;
+    };
+    struct {
+        uint32_t stepping : 4, model : 4, family : 4, rsvd1 : 20;
+    };
+    uint32_t feature_flags;
+    uint32_t rsvd2;
+    uint32_t rsvd3;
 } __packed;
 typedef struct mpc_processor_entry mpc_processor_entry_t;
 
 struct mpc_bus_entry {
-   uint8_t type;
-   uint8_t id;
-   uint8_t type_str[6];
+    uint8_t type;
+    uint8_t id;
+    uint8_t type_str[6];
 } __packed;
 typedef struct mpc_bus_entry mpc_bus_entry_t;
 
 struct mpc_ioapic_entry {
-   uint8_t type;
-   uint8_t id;
-   uint8_t version;
-   struct {
-       uint8_t en:1, rsvd:7;
-   };
-   uint32_t base_addr;
+    uint8_t type;
+    uint8_t id;
+    uint8_t version;
+    struct {
+        uint8_t en : 1, rsvd : 7;
+    };
+    uint32_t base_addr;
 } __packed;
 typedef struct mpc_ioapic_entry mpc_ioapic_entry_t;
 
-#define MPC_IOINT_INT 0
-#define MPC_IOINT_NMI 1
-#define MPC_IOINT_SMI 2
+#define MPC_IOINT_INT    0
+#define MPC_IOINT_NMI    1
+#define MPC_IOINT_SMI    2
 #define MPC_IOINT_EXTINT 3
 
-#define MPC_IOINT_POLARITY_BS 0x00
-#define MPC_IOINT_POLARITY_AH 0x01
+#define MPC_IOINT_POLARITY_BS   0x00
+#define MPC_IOINT_POLARITY_AH   0x01
 #define MPC_IOINT_POLARITY_RSVD 0x10
-#define MPC_IOINT_POLARITY_AL 0x11
+#define MPC_IOINT_POLARITY_AL   0x11
 
-#define MPC_IOINT_TRIGGER_BS 0x00
-#define MPC_IOINT_TRIGGER_ET 0x01
+#define MPC_IOINT_TRIGGER_BS   0x00
+#define MPC_IOINT_TRIGGER_ET   0x01
 #define MPC_IOINT_TRIGGER_RSVD 0x10
-#define MPC_IOINT_TRIGGER_LT 0x11
+#define MPC_IOINT_TRIGGER_LT   0x11
 
 struct mpc_ioint_entry {
-   uint8_t type;
-   uint8_t int_type;
-   struct {
-       uint16_t po:1, el:1, rsvd:14;
-   };
-   uint8_t src_bus_id;
-   uint8_t src_bus_irq;
-   uint8_t dst_ioapic_id;
-   uint8_t dst_ioapic_intin;
+    uint8_t type;
+    uint8_t int_type;
+    struct {
+        uint16_t po : 1, el : 1, rsvd : 14;
+    };
+    uint8_t src_bus_id;
+    uint8_t src_bus_irq;
+    uint8_t dst_ioapic_id;
+    uint8_t dst_ioapic_intin;
 } __packed;
 typedef struct mpc_ioint_entry mpc_ioint_entry_t;
 
 struct mpc_lint_entry {
-   uint8_t type;
-   uint8_t int_type;
-   struct {
-       uint16_t po:1, el:1, rsvd:14;
-   };
-   uint8_t src_bus_id;
-   uint8_t src_bus_irq;
-   uint8_t dst_lapic_id;
-   uint8_t dst_lapic_lintin;
+    uint8_t type;
+    uint8_t int_type;
+    struct {
+        uint16_t po : 1, el : 1, rsvd : 14;
+    };
+    uint8_t src_bus_id;
+    uint8_t src_bus_irq;
+    uint8_t dst_lapic_id;
+    uint8_t dst_lapic_lintin;
 } __packed;
 typedef struct mpc_lint_entry mpc_lint_entry_t;
 

--- a/include/smp/smp.h
+++ b/include/smp/smp.h
@@ -33,7 +33,7 @@
 
 /* External declarations */
 
-extern void smp_init(void);
+extern void     smp_init(void);
 extern unsigned get_nr_cpus(void);
 
 /* Static declarations */

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -25,9 +25,9 @@
 #ifndef KTF_SPINLOCK_H
 #define KTF_SPINLOCK_H
 
+#include <atomic.h>
 #include <ktf.h>
 #include <lib.h>
-#include <atomic.h>
 
 #define LOCK_BIT 0U
 
@@ -39,7 +39,7 @@ typedef volatile unsigned int spinlock_t;
 
 static inline void spin_lock(spinlock_t *lock) {
     ASSERT(lock);
-    while(test_and_set_bit(LOCK_BIT, lock))
+    while (test_and_set_bit(LOCK_BIT, lock))
         cpu_relax();
 }
 

--- a/include/string.h
+++ b/include/string.h
@@ -89,38 +89,34 @@ static inline unsigned char toupper(unsigned char c)
 static inline void *memset(void *s, int c, size_t n) {
     unsigned long d0;
 
-    asm volatile(
-        "mov %1, %%" STR(_ASM_CX) "\n"
-        "rep stosb\n"
-        "mov %2, %%" STR(_ASM_CX) "\n"
-        "rep " STR(STOS) "\n"
-    : "=&D" (d0)
-    : "ir" (n & (ARCH_SIZE - 1)),
-      "ir" (n / ARCH_SIZE),
-      "0" (s),
-      "a" (SPRAY_VAL * c)
-    : STR(_ASM_CX), "memory"
-    );
+    /* clang-format off */
+    asm volatile("mov %1, %%" STR(_ASM_CX) "\n"
+                 "rep stosb\n"
+                 "mov %2, %%" STR(_ASM_CX) "\n"
+                 "rep " STR(STOS) "\n"
+                 : "=&D"(d0)
+                 : "ir"(n & (ARCH_SIZE - 1)), "ir"(n / ARCH_SIZE), "0"(s),
+                   "a"(SPRAY_VAL * c)
+                 : STR(_ASM_CX), "memory");
+    /* clang-format on */
 
-   return s;
+    return s;
 }
 
 static inline void *memcpy(void *d, void *s, size_t n) {
     unsigned long d0;
 
-    asm volatile(
-        "mov %2, %%" STR(_ASM_CX) "\n"
-        "rep movsb \n"
-        "mov %3, %%" STR(_ASM_CX) "\n"
-        "rep " STR(MOVS) "\n"
-    : "=&D" (d0), "+&S" (s)
-    : "ir" (n & (ARCH_SIZE - 1)),
-      "ir" (n / ARCH_SIZE),
-      "0" (d)
-    : STR(_ASM_CX), "memory"
-    );
+    /* clang-format off */
+    asm volatile("mov %2, %%" STR(_ASM_CX) "\n"
+                 "rep movsb \n"
+                 "mov %3, %%" STR(_ASM_CX) "\n"
+                 "rep " STR(MOVS) "\n"
+                 : "=&D"(d0), "+&S"(s)
+                 : "ir"(n & (ARCH_SIZE - 1)), "ir"(n / ARCH_SIZE), "0"(d)
+                 : STR(_ASM_CX), "memory");
+    /* clang-format on */
 
-   return d;
+    return d;
 }
 
 static inline int memcmp(const void *m1, const void *m2, size_t n)

--- a/include/string.h
+++ b/include/string.h
@@ -26,34 +26,21 @@
 #define KTF_STRING_H
 #include <asm-macros.h>
 
-static inline __used int isspace(int c) {
-    return c == ' ' || c == '\t';
-}
+static inline __used int isspace(int c) { return c == ' ' || c == '\t'; }
 
-static inline __used int isdigit(int c) {
-    return c >= '0' && c <= '9';
-}
+static inline __used int isdigit(int c) { return c >= '0' && c <= '9'; }
 
 static inline __used int isxdigit(int c) {
-    return (isdigit(c) || (c >= 'A' && c <= 'F') ||
-           (c >= 'a' && c <= 'f'));
+    return (isdigit(c) || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'));
 }
 
-static inline __used int isascii(int c) {
-    return c >= 0 && c <= 127;
-}
+static inline __used int isascii(int c) { return c >= 0 && c <= 127; }
 
-static inline __used int islower(int c) {
-    return c >= 'a' && c <= 'z';
-}
+static inline __used int islower(int c) { return c >= 'a' && c <= 'z'; }
 
-static inline int isupper(int c) {
-    return c >= 'A' && c <= 'Z';
-}
+static inline int isupper(int c) { return c >= 'A' && c <= 'Z'; }
 
-static inline int isalpha(int c) {
-    return islower(c) || isupper(c);
-}
+static inline int isalpha(int c) { return islower(c) || isupper(c); }
 
 static inline size_t strlen(const char *str) {
     size_t len = 0;
@@ -64,24 +51,22 @@ static inline size_t strlen(const char *str) {
     return len;
 }
 
-static inline unsigned char tolower(unsigned char c)
-{
-        return isupper(c) ? c - ('A'-'a') : c;
+static inline unsigned char tolower(unsigned char c) {
+    return isupper(c) ? c - ('A' - 'a') : c;
 }
 
-static inline unsigned char toupper(unsigned char c)
-{
-        return islower(c) ? c + ('A'-'a') : c;
+static inline unsigned char toupper(unsigned char c) {
+    return islower(c) ? c + ('A' - 'a') : c;
 }
 
 #if defined(__i386__)
 #define SPRAY_VAL 0x01010101U
-#define STOS stosl
-#define MOVS movsl
-#elif defined (__x86_64__)
+#define STOS      stosl
+#define MOVS      movsl
+#elif defined(__x86_64__)
 #define SPRAY_VAL 0x0101010101010101UL
-#define STOS stosq
-#define MOVS movsq
+#define STOS      stosq
+#define MOVS      movsq
 #endif
 
 #define ARCH_SIZE (sizeof(void *))
@@ -119,16 +104,15 @@ static inline void *memcpy(void *d, void *s, size_t n) {
     return d;
 }
 
-static inline int memcmp(const void *m1, const void *m2, size_t n)
-{
-    const uint8_t *_m1 = m1;
-    const uint8_t *_m2 = m2;
+static inline int memcmp(const void *m1, const void *m2, size_t n) {
+    const uint8_t *  _m1 = m1;
+    const uint8_t *  _m2 = m2;
     register uint8_t res = 0;
 
     if (m1 == m2)
         return 0;
 
-    while(n--) {
+    while (n--) {
         if ((res = (*_m1++ - *_m2++)) != 0)
             break;
     }
@@ -139,13 +123,13 @@ static inline int memcmp(const void *m1, const void *m2, size_t n)
 static inline char *strcpy(char *d, const char *s) {
     int d0, d1, d2;
 
-    asm volatile ("1: lodsb \n"
-                  "   stosb \n"
-                  "   testb %%al,%%al \n"
-                  "   jne 1b"
-    : "=&S" (d0), "=&D" (d1), "=&a" (d2)
-    : "0" (s), "1" (d)
-    : "memory");
+    asm volatile("1: lodsb \n"
+                 "   stosb \n"
+                 "   testb %%al,%%al \n"
+                 "   jne 1b"
+                 : "=&S"(d0), "=&D"(d1), "=&a"(d2)
+                 : "0"(s), "1"(d)
+                 : "memory");
 
     return d;
 }
@@ -156,7 +140,7 @@ static inline int strcmp(const char *s1, const char *s2) {
     if (s1 == s2)
         return 0;
 
-    while(1) {
+    while (1) {
         if ((res = *s1 - *s2++) != 0 || !*s1++)
             break;
     }
@@ -170,7 +154,7 @@ static inline int strncmp(const char *s1, const char *s2, size_t n) {
     if (s1 == s2)
         return 0;
 
-    while(n--) {
+    while (n--) {
         if ((res = *s1 - *s2++) != 0 || !*s1++)
             break;
     }
@@ -181,8 +165,8 @@ static inline int strncmp(const char *s1, const char *s2, size_t n) {
 /* External declarations */
 
 extern unsigned long strtoul(const char *nptr, char **endptr, int base);
-extern long strtol(const char *nptr, char **endptr, int base);
-extern int vsnprintf(char *str, size_t size, char const *fmt, va_list ap);
-extern void snprintf(char *buf, size_t size, const char *fmt, ...);
+extern long          strtol(const char *nptr, char **endptr, int base);
+extern int           vsnprintf(char *str, size_t size, char const *fmt, va_list ap);
+extern void          snprintf(char *buf, size_t size, const char *fmt, ...);
 
 #endif /* KTF_STRING_H */


### PR DESCRIPTION
It can be used with clang-format tool for formatting.

Disable clang auto formatting for places where current format is
better.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
