### PR TITLE
workflows: fix clang-format action

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -13,4 +13,5 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@v0.8
       with:
         source: '.'
+        clangFormatVersion: 10
         extensions: 'h,c'


### PR DESCRIPTION
Use newer clang-format 10 to enable more options.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
