### PR TITLE
style: disable clang-format on string.c; unify style in all files; add README instructions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignConsecutiveMacros: true
 AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: true
+AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Right
 AlignOperands:   true
 AlignTrailingComments: true

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ make debug
 #### Xen guest
 
 Use the following guest domain config example for booting KTF with Xen:
-```
+```python
 name="kernel64"
 builder="hvm"
 memory=1024
@@ -115,11 +115,32 @@ The style for this project is defined in `.clang-format` file in the main direct
 
 Use the following command to apply the style automatically to the file you modify:
 
-```
+```bash
 clang-format -style=file -Werror -i MODIFIED_FILE
 ```
 
 For more information refer to: https://clang.llvm.org/docs/ClangFormat.html
+
+This project uses https://github.com/DoozyX/clang-format-lint-action action workflow to detect style mismatches automatically.
+For more information refer to: https://github.com/marketplace/actions/clang-format-lint
+
+### Running the clang-format workflow locally
+
+#### Build `clang-format-lint` container
+
+```bash
+docker build -t clang-format-lint github.com/DoozyX/clang-format-lint-action
+```
+
+This has to be done only once.
+
+#### Patch your files
+
+```bash
+for ext in c h; do
+    docker run --rm --workdir /src -v $(pwd):/src clang-format-lint --clang-format-executable /clang-format/clang-format10 -r --exclude .git $(find . -name \*.$ext -print) | patch -p1
+done
+```
 
 ## Credits and Attributions
 

--- a/arch/x86/apic.c
+++ b/arch/x86/apic.c
@@ -23,10 +23,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <console.h>
 #include <ktf.h>
 #include <lib.h>
 #include <page.h>
-#include <console.h>
 #include <processor.h>
 
 #include <apic.h>
@@ -34,11 +34,9 @@
 apic_mode_t apic_mode = APIC_MODE_UNKNOWN;
 
 static const char *apic_mode_names[] = {
-    [APIC_MODE_UNKNOWN]  = "Unknown",
-    [APIC_MODE_NONE]     = "None",
-    [APIC_MODE_DISABLED] = "Disabled",
-    [APIC_MODE_XAPIC]    = "XAPIC",
-    [APIC_MODE_X2APIC]   = "X2APIC",
+    [APIC_MODE_UNKNOWN] = "Unknown",   [APIC_MODE_NONE] = "None",
+    [APIC_MODE_DISABLED] = "Disabled", [APIC_MODE_XAPIC] = "XAPIC",
+    [APIC_MODE_X2APIC] = "X2APIC",
 };
 
 int init_apic(enum apic_mode mode) {
@@ -71,8 +69,8 @@ int init_apic(enum apic_mode mode) {
         }
     }
 
-    printk("Initializing APIC mode: %s -> %s\n",
-           apic_mode_names[apic_mode], apic_mode_names[mode]);
+    printk("Initializing APIC mode: %s -> %s\n", apic_mode_names[apic_mode],
+           apic_mode_names[mode]);
 
     /* Disable APIC */
     apic_base &= ~(APIC_BASE_EXTD | APIC_BASE_ENABLE);
@@ -90,7 +88,8 @@ int init_apic(enum apic_mode mode) {
      * X2APIC uses MSRs for accesses, so no mapping needed.
      */
     if (apic_mode == APIC_MODE_XAPIC)
-        vmap(_ptr(DEFAULT_APIC_BASE), paddr_to_mfn(DEFAULT_APIC_BASE), PAGE_ORDER_4K, L1_PROT);
+        vmap(_ptr(DEFAULT_APIC_BASE), paddr_to_mfn(DEFAULT_APIC_BASE), PAGE_ORDER_4K,
+             L1_PROT);
 
     apic_write(APIC_SPIV, APIC_SPIV_APIC_ENABLED | 0xff);
     return 0;

--- a/arch/x86/boot/multiboot.c
+++ b/arch/x86/boot/multiboot.c
@@ -22,10 +22,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <ktf.h>
-#include <string.h>
 #include <console.h>
+#include <ktf.h>
 #include <multiboot.h>
+#include <string.h>
 
 static multiboot_info_t *multiboot_info;
 
@@ -33,12 +33,12 @@ static multiboot_memory_map_t *multiboot_mmap;
 static unsigned multiboot_mmap_num;
 
 static const char *multiboot_region_type_name[] = {
-    [MULTIBOOT_MEMORY_UNDEFINED]        = "Undefined",
-    [MULTIBOOT_MEMORY_AVAILABLE]        = "Available",
-    [MULTIBOOT_MEMORY_RESERVED]         = "Reserved",
+    [MULTIBOOT_MEMORY_UNDEFINED] = "Undefined",
+    [MULTIBOOT_MEMORY_AVAILABLE] = "Available",
+    [MULTIBOOT_MEMORY_RESERVED] = "Reserved",
     [MULTIBOOT_MEMORY_ACPI_RECLAIMABLE] = "ACPI Reclaimable",
-    [MULTIBOOT_MEMORY_NVS]              = "NVS",
-    [MULTIBOOT_MEMORY_BADRAM]           = "Bad RAM",
+    [MULTIBOOT_MEMORY_NVS] = "NVS",
+    [MULTIBOOT_MEMORY_BADRAM] = "Bad RAM",
 };
 
 static inline bool has_mbi_flag(unsigned flag) {
@@ -52,10 +52,10 @@ void display_multiboot_mmap(void) {
     printk("\nPhysical Memory Map\n");
 
     if (!has_mbi_flag(MULTIBOOT_INFO_MEM_MAP)) {
-        printk("REGION: [0x%016lx - 0x%016lx] Lower memory\n",
-               0, multiboot_info->mem_lower * KB(1));
-        printk("REGION: [0x%016lx - 0x%016lx] Upper memory\n",
-               MB(1), MB(1) + (multiboot_info->mem_upper * KB(1)));
+        printk("REGION: [0x%016lx - 0x%016lx] Lower memory\n", 0,
+               multiboot_info->mem_lower * KB(1));
+        printk("REGION: [0x%016lx - 0x%016lx] Upper memory\n", MB(1),
+               MB(1) + (multiboot_info->mem_upper * KB(1)));
         return;
     }
 
@@ -63,9 +63,8 @@ void display_multiboot_mmap(void) {
         multiboot_memory_map_t *entry = &multiboot_mmap[i];
 
         if (entry->type != MULTIBOOT_MEMORY_UNDEFINED) {
-            printk("REGION: [0x%016lx - 0x%016lx] %s\n",
-                   entry->addr, entry->addr + entry->len,
-                   multiboot_region_type_name[entry->type]);
+            printk("REGION: [0x%016lx - 0x%016lx] %s\n", entry->addr,
+                   entry->addr + entry->len, multiboot_region_type_name[entry->type]);
         }
     }
 }
@@ -114,7 +113,6 @@ int mbi_get_avail_memory_range(unsigned index, addr_range_t *r) {
                 r->end = _ptr(_paddr(r->start + entry->len));
                 return 0;
             }
-
         }
     }
     else if (has_mbi_flag(MULTIBOOT_INFO_MEMORY)) {

--- a/arch/x86/boot/segment.c
+++ b/arch/x86/boot/segment.c
@@ -23,15 +23,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <ktf.h>
 #include <asm-macros.h>
+#include <ktf.h>
 #include <segment.h>
 
 gdt_desc_t boot_gdt[] __aligned(16) __data_init = {
+    /* clang-format off */
     [GDT_NULL].desc      = GDT_ENTRY(0x0, 0x0, 0x0),
     [GDT_KERN_CS32].desc = GDT_ENTRY(DESC_FLAGS(GR, SZ, P, DPL0, S, CODE, R, A), 0x0, 0xfffff),
     [GDT_KERN_DS32].desc = GDT_ENTRY(DESC_FLAGS(GR, SZ, P, DPL0, S, DATA, W, A), 0x0, 0xfffff),
     [GDT_KERN_CS64].desc = GDT_ENTRY(DESC_FLAGS(GR,  L, P, DPL0, S, CODE, R, A), 0x0, 0x00000),
+    /* clang-format on */
 };
 
 gdt_ptr_t boot_gdt_ptr __data_init = {

--- a/arch/x86/traps.c
+++ b/arch/x86/traps.c
@@ -23,50 +23,51 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <console.h>
 #include <ktf.h>
 #include <lib.h>
-#include <segment.h>
-#include <console.h>
-#include <string.h>
-#include <setup.h>
-#include <traps.h>
-#include <processor.h>
 #include <percpu.h>
+#include <processor.h>
+#include <segment.h>
+#include <setup.h>
+#include <string.h>
+#include <traps.h>
 
 #include <mm/vmm.h>
 
 extern void ret2kern_handler(void);
 
 static void init_tss(percpu_t *percpu) {
-#if defined (__i386__)
+#if defined(__i386__)
     percpu->tss_df.iopb = sizeof(percpu->tss_df);
     percpu->tss_df.esp0 = _ul(get_free_page_top(GFP_KERNEL));
-    percpu->tss_df.ss   = __KERN_DS;
-    percpu->tss_df.ds   = __KERN_DS;
-    percpu->tss_df.es   = __KERN_DS;
-    percpu->tss_df.fs   = __KERN_DS;
-    percpu->tss_df.gs   = __KERN_DS;
-    percpu->tss_df.eip  = _ul(entry_DF);
-    percpu->tss_df.cs   = __KERN_CS;
-    percpu->tss_df.cr3  = _ul(cr3.reg);
+    percpu->tss_df.ss = __KERN_DS;
+    percpu->tss_df.ds = __KERN_DS;
+    percpu->tss_df.es = __KERN_DS;
+    percpu->tss_df.fs = __KERN_DS;
+    percpu->tss_df.gs = __KERN_DS;
+    percpu->tss_df.eip = _ul(entry_DF);
+    percpu->tss_df.cs = __KERN_CS;
+    percpu->tss_df.cr3 = _ul(cr3.reg);
 
     /* Assign identity mapping of the tss_df, because GDT has only 32-bit base. */
-    percpu->gdt[GDT_TSS_DF].desc = \
-        GDT_ENTRY(DESC_FLAGS(SZ, P, CODE, A), virt_to_paddr(&percpu->tss_df), sizeof(percpu->tss_df) - 1);
+    percpu->gdt[GDT_TSS_DF].desc =
+        GDT_ENTRY(DESC_FLAGS(SZ, P, CODE, A), virt_to_paddr(&percpu->tss_df),
+                  sizeof(percpu->tss_df) - 1);
 
     /* FIXME */
-    percpu->tss.esp0   = _ul(get_free_page_top(GFP_KERNEL));
-    percpu->tss.ss0    = __KERN_DS;
-    percpu->tss.cr3    = _ul(cr3.reg);
+    percpu->tss.esp0 = _ul(get_free_page_top(GFP_KERNEL));
+    percpu->tss.ss0 = __KERN_DS;
+    percpu->tss.cr3 = _ul(cr3.reg);
 #elif defined(__x86_64__)
-    percpu->tss.rsp0   = _ul(get_free_page_top(GFP_KERNEL));
+    percpu->tss.rsp0 = _ul(get_free_page_top(GFP_KERNEL));
     percpu->tss.ist[0] = _ul(get_free_page_top(GFP_KERNEL));
 #endif
     percpu->tss.iopb = sizeof(percpu->tss);
 
     /* Assign identity mapping of the tss, because GDT has only 32-bit base. */
-    percpu->gdt[GDT_TSS].desc = \
-        GDT_ENTRY(DESC_FLAGS(SZ, P, CODE, A), virt_to_paddr(&percpu->tss), sizeof(percpu->tss) - 1);
+    percpu->gdt[GDT_TSS].desc = GDT_ENTRY(
+        DESC_FLAGS(SZ, P, CODE, A), virt_to_paddr(&percpu->tss), sizeof(percpu->tss) - 1);
 #if defined(__x86_64__)
     percpu->gdt[GDT_TSS + 1].desc = GDT_ENTRY(0x0, 0x0, 0x0);
 #endif
@@ -76,6 +77,7 @@ static void init_tss(percpu_t *percpu) {
 }
 
 static void init_gdt(percpu_t *percpu) {
+    /* clang-format off */
     percpu->gdt[GDT_NULL].desc      = GDT_ENTRY(0x0, 0x0, 0x0);
     percpu->gdt[GDT_KERN_CS32].desc = GDT_ENTRY(DESC_FLAGS(GR, SZ, P, DPL0, S, CODE, R, A), 0x0, 0xfffff);
     percpu->gdt[GDT_KERN_DS32].desc = GDT_ENTRY(DESC_FLAGS(GR, SZ, P, DPL0, S, DATA, W, A), 0x0, 0xfffff);
@@ -87,6 +89,7 @@ static void init_gdt(percpu_t *percpu) {
 
     /* Assign identity mapping of the percpu, because GDT has only 32-bit base. */
     percpu->gdt[GDT_PERCPU].desc = GDT_ENTRY(DESC_FLAGS(GR, L, P, DPL3, S, CODE, R, A), virt_to_paddr(percpu), PAGE_SIZE);
+    /* clang-format on */
 
     percpu->gdt_ptr.size = sizeof(percpu->gdt) - 1;
     percpu->gdt_ptr.addr = _ul(&percpu->gdt);
@@ -110,6 +113,7 @@ void init_traps(unsigned int cpu) {
     percpu->idt_ptr.size = (sizeof(percpu->idt) * MAX_INT) - 1;
     percpu->idt_ptr.addr = _ul(percpu->idt);
 
+    /* clang-format off */
     set_intr_gate(&percpu->idt[X86_EX_DE],  __KERN_CS, _ul(entry_DE),  GATE_DPL0, GATE_PRESENT, 0);
     set_intr_gate(&percpu->idt[X86_EX_DB],  __KERN_CS, _ul(entry_DB),  GATE_DPL0, GATE_PRESENT, 0);
     set_intr_gate(&percpu->idt[X86_EX_NMI], __KERN_CS, _ul(entry_NMI), GATE_DPL0, GATE_PRESENT, 0);
@@ -136,6 +140,7 @@ void init_traps(unsigned int cpu) {
 
     /* User mode return to kernel handler */
     set_intr_gate(&percpu->idt[X86_RET2KERN_INT], __KERN_CS, _ul(ret2kern_handler), GATE_DPL3, GATE_PRESENT, 0);
+    /* clang-format on */
 
     barrier();
     lidt(&percpu->idt_ptr);
@@ -155,24 +160,16 @@ static void dump_general_regs(const struct cpu_regs *regs) {
            "RBP=0x%016lx R14=0x%016lx\n"
            "RSP=0x%016lx R15=0x%016lx\n"
            "\nRIP=0x%016lx\n\n",
-           regs->_ASM_AX, regs->r8,
-           regs->_ASM_BX, regs->r9,
-           regs->_ASM_CX, regs->r10,
-           regs->_ASM_DX, regs->r11,
-           regs->_ASM_SI, regs->r12,
-           regs->_ASM_DI, regs->r13,
-           regs->_ASM_BP, regs->r14,
-           regs->_ASM_SP, regs->r15,
-           regs->_ASM_IP);
+           regs->_ASM_AX, regs->r8, regs->_ASM_BX, regs->r9, regs->_ASM_CX, regs->r10,
+           regs->_ASM_DX, regs->r11, regs->_ASM_SI, regs->r12, regs->_ASM_DI, regs->r13,
+           regs->_ASM_BP, regs->r14, regs->_ASM_SP, regs->r15, regs->_ASM_IP);
 }
 
 static void dump_control_regs(const struct cpu_regs *regs) {
     printk("CR0=0x%016lx CR2=0x%016lx\n"
            "CR3=0x%016lx CR4=0x%016lx\n"
            "CR8=0x%016lx\n\n",
-           read_cr0(), read_cr2(),
-           read_cr3(), read_cr4(),
-           read_cr8());
+           read_cr0(), read_cr2(), read_cr3(), read_cr4(), read_cr8());
 }
 
 static void dump_segment_regs(const struct cpu_regs *regs) {
@@ -181,9 +178,8 @@ static void dump_segment_regs(const struct cpu_regs *regs) {
            "ES=0x%04x FS=0x%04x GS=0x%04x\n"
            "EXCEPTION:\n"
            "CS=0x%04x SS=0x%04x\n\n",
-           read_cs(), read_ds(), read_ss(),
-           read_es(), read_fs(), read_gs(),
-           regs->cs, regs->ss);
+           read_cs(), read_ds(), read_ss(), read_es(), read_fs(), read_gs(), regs->cs,
+           regs->ss);
 }
 
 static void dump_flags(const struct cpu_regs *regs) {
@@ -204,7 +200,6 @@ static void dump_stack(const struct cpu_regs *regs, int words, int lines) {
         printk("%016lx ", sp[i]);
     }
     printk("\n\n");
-
 }
 
 static void dump_regs(const struct cpu_regs *regs) {
@@ -215,61 +210,40 @@ static void dump_regs(const struct cpu_regs *regs) {
     dump_stack(regs, 4, 16);
 }
 
-static const char * const exception_names[] = {
-    [X86_EX_DE]  = "DE",
-    [X86_EX_DB]  = "DB",
-    [X86_EX_NMI] = "NMI",
-    [X86_EX_BP]  = "BP",
-    [X86_EX_OF]  = "OF",
-    [X86_EX_BR]  = "BR",
-    [X86_EX_UD]  = "UD",
-    [X86_EX_NM]  = "NM",
-    [X86_EX_DF]  = "DF",
-    [X86_EX_CS]  = "CS",
-    [X86_EX_TS]  = "TS",
-    [X86_EX_NP]  = "NP",
-    [X86_EX_SS]  = "SS",
-    [X86_EX_GP]  = "GP",
-    [X86_EX_PF]  = "PF",
-    [X86_EX_SPV] = "SPV",
-    [X86_EX_MF]  = "MF",
-    [X86_EX_AC]  = "AC",
-    [X86_EX_MC]  = "MC",
-    [X86_EX_XM]  = "XM",
-    [X86_EX_VE]  = "VE",
-    [X86_EX_SE]  = "SE",
+static const char *const exception_names[] = {
+    [X86_EX_DE] = "DE", [X86_EX_DB] = "DB", [X86_EX_NMI] = "NMI", [X86_EX_BP] = "BP",
+    [X86_EX_OF] = "OF", [X86_EX_BR] = "BR", [X86_EX_UD] = "UD",   [X86_EX_NM] = "NM",
+    [X86_EX_DF] = "DF", [X86_EX_CS] = "CS", [X86_EX_TS] = "TS",   [X86_EX_NP] = "NP",
+    [X86_EX_SS] = "SS", [X86_EX_GP] = "GP", [X86_EX_PF] = "PF",   [X86_EX_SPV] = "SPV",
+    [X86_EX_MF] = "MF", [X86_EX_AC] = "AC", [X86_EX_MC] = "MC",   [X86_EX_XM] = "XM",
+    [X86_EX_VE] = "VE", [X86_EX_SE] = "SE",
 };
 
-static const char * const tlb_names[] = {
+static const char *const tlb_names[] = {
     [X86_EX_SEL_TLB_GDT] = "GDT",
     [X86_EX_SEL_TLB_IDT] = "IDT",
     [X86_EX_SEL_TLB_LDT] = "LDT",
     [X86_EX_SEL_TLB_IDT2] = "IDT",
 };
 
-static char *x86_ex_decode_error_code(char *buf, size_t size, uint32_t vector, x86_ex_error_code_t ec) {
+static char *x86_ex_decode_error_code(char *buf, size_t size, uint32_t vector,
+                                      x86_ex_error_code_t ec) {
     switch (vector) {
     case X86_EX_PF:
-       snprintf(buf, size, "%c%c%c%c%c ",
-                ec.P ? 'P' : '-',
-                ec.W ? 'W' : 'R',
-                ec.U ? 'U' : 'S',
-                ec.R ? 'R' : '-',
-                ec.I ? 'I' : '-');
-       break;
+        snprintf(buf, size, "%c%c%c%c%c ", ec.P ? 'P' : '-', ec.W ? 'W' : 'R',
+                 ec.U ? 'U' : 'S', ec.R ? 'R' : '-', ec.I ? 'I' : '-');
+        break;
     case X86_EX_TS:
     case X86_EX_NP:
     case X86_EX_SS:
     case X86_EX_GP:
     case X86_EX_AC:
-       snprintf(buf, size, "%s%s[0x%02x] ",
-                ec.E ? "#EXT " : "",
-                tlb_names[ec.TLB],
-                ec.index);
-       break;
+        snprintf(buf, size, "%s%s[0x%02x] ", ec.E ? "#EXT " : "", tlb_names[ec.TLB],
+                 ec.index);
+        break;
     default:
-       snprintf(buf, size, "0x%08x ", 0x0);
-       break;
+        snprintf(buf, size, "0x%08x ", 0x0);
+        break;
     }
 
     return buf;
@@ -283,8 +257,10 @@ void do_exception(struct cpu_regs *regs) {
     if (has_error_code(regs->vector))
         x86_ex_decode_error_code(ec_str, sizeof(ec_str), regs->vector, regs->error_code);
 
-    snprintf(panic_str, sizeof(panic_str), "#%s %sat IP: 0x%02x:0x%016lx SP: 0x%02x:0x%016lx\n",
-             exception_names[regs->vector], ec_str, regs->cs, regs->_ASM_IP, regs->ss, regs->_ASM_SP);
+    snprintf(panic_str, sizeof(panic_str),
+             "#%s %sat IP: 0x%02x:0x%016lx SP: 0x%02x:0x%016lx\n",
+             exception_names[regs->vector], ec_str, regs->cs, regs->_ASM_IP, regs->ss,
+             regs->_ASM_SP);
 
     panic(panic_str);
 }

--- a/common/console.c
+++ b/common/console.c
@@ -23,15 +23,15 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <console.h>
 #include <ktf.h>
 #include <lib.h>
 #include <setup.h>
-#include <string.h>
-#include <console.h>
 #include <spinlock.h>
+#include <string.h>
 
-#include <drivers/vga.h>
 #include <drivers/serial.h>
+#include <drivers/vga.h>
 
 #include <smp/smp.h>
 
@@ -53,10 +53,10 @@ static void vprintk(const char *fmt, va_list args) {
 
     rc = vsnprintf(buf, sizeof(buf), fmt, args);
 
-    if ( rc > (int)sizeof(buf) )
+    if (rc > (int) sizeof(buf))
         panic("vprintk() buffer overflow\n");
 
-    for ( i = 0; i < num_console_callbacks; i++ )
+    for (i = 0; i < num_console_callbacks; i++)
         console_callbacks[i](buf, rc);
 
     spin_unlock(&lock);
@@ -70,21 +70,15 @@ void printk(const char *fmt, ...) {
     va_end(args);
 }
 
-void putchar(int c) {
-    putc(SERIAL_CONSOLE, c);
-}
+void putchar(int c) { putc(SERIAL_CONSOLE, c); }
 
 void serial_console_write(const char *buf, size_t len) {
     serial_write(SERIAL_CONSOLE, buf, len);
 }
 
-void qemu_console_write(const char *buf, size_t len) {
-    puts(QEMU_CONSOLE, buf, len);
-}
+void qemu_console_write(const char *buf, size_t len) { puts(QEMU_CONSOLE, buf, len); }
 
-void vga_console_write(const char *buf, size_t len) {
-    vga_write(buf, len, VGA_WHITE);
-}
+void vga_console_write(const char *buf, size_t len) { vga_write(buf, len, VGA_WHITE); }
 
 void register_console_callback(console_callback_t cb) {
     console_callbacks[num_console_callbacks++] = cb;
@@ -102,6 +96,6 @@ void __noreturn panic(const char *fmt, ...) {
 
     printk("******************************\n");
 
-    while(1)
+    while (1)
         halt();
 }

--- a/common/kernel.c
+++ b/common/kernel.c
@@ -22,24 +22,26 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <console.h>
 #include <ktf.h>
 #include <lib.h>
-#include <console.h>
-#include <setup.h>
 #include <multiboot.h>
 #include <percpu.h>
 #include <sched.h>
+#include <setup.h>
 
 extern void _long_to_real(void);
 
-extern int usermode_call_asm(user_func_t fn, void *fn_arg, unsigned long ret2kern_sp, unsigned long user_stack);
+extern int usermode_call_asm(user_func_t fn, void *fn_arg, unsigned long ret2kern_sp,
+                             unsigned long user_stack);
 
 void ret2kern_handler(void) {
-    asm volatile("mov %%gs:(%0), %%" STR(_ASM_SP) :: "r" (offsetof(percpu_t, ret2kern_sp)));
+    asm volatile("mov %%gs:(%0), %%" STR(_ASM_SP)::"r"(offsetof(percpu_t, ret2kern_sp)));
 }
 
 int usermode_call(user_func_t fn, void *fn_arg) {
-    return usermode_call_asm(fn, fn_arg, offsetof(percpu_t, ret2kern_sp), offsetof(percpu_t, user_stack));
+    return usermode_call_asm(fn, fn_arg, offsetof(percpu_t, ret2kern_sp),
+                             offsetof(percpu_t, user_stack));
 }
 
 void kernel_main(void) {
@@ -60,6 +62,6 @@ void kernel_main(void) {
 
     printk("All tasks done.\n");
 
-    while(1)
+    while (1)
         halt();
 }

--- a/common/percpu.c
+++ b/common/percpu.c
@@ -22,10 +22,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <console.h>
 #include <ktf.h>
 #include <lib.h>
 #include <list.h>
-#include <console.h>
 #include <percpu.h>
 
 #include <mm/vmm.h>
@@ -41,7 +41,7 @@ void init_percpu(void) {
 percpu_t *get_percpu_page(unsigned int cpu) {
     percpu_t *percpu;
 
-    list_for_each_entry(percpu, &percpu_frames, list) {
+    list_for_each_entry (percpu, &percpu_frames, list) {
         if (percpu->id == cpu)
             return percpu;
     }

--- a/common/sched.c
+++ b/common/sched.c
@@ -22,14 +22,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <console.h>
 #include <ktf.h>
 #include <lib.h>
 #include <list.h>
 #include <sched.h>
-#include <string.h>
-#include <console.h>
-#include <spinlock.h>
 #include <setup.h>
+#include <spinlock.h>
+#include <string.h>
 
 #include <smp/smp.h>
 
@@ -49,11 +49,11 @@ void init_tasks(void) {
 }
 
 static const char *task_state_names[] = {
-    [TASK_STATE_NEW]       = "NEW",
-    [TASK_STATE_READY]     = "READY",
+    [TASK_STATE_NEW] = "NEW",
+    [TASK_STATE_READY] = "READY",
     [TASK_STATE_SCHEDULED] = "SCHEDULED",
-    [TASK_STATE_RUNNING]   = "RUNNING",
-    [TASK_STATE_DONE]      = "DONE",
+    [TASK_STATE_RUNNING] = "RUNNING",
+    [TASK_STATE_DONE] = "DONE",
 };
 
 static inline void set_task_state(task_t *task, task_state_t state) {
@@ -127,7 +127,7 @@ task_t *new_task(const char *name, task_func_t func, void *arg) {
 task_t *get_task_by_id(tid_t id) {
     task_t *task;
 
-    list_for_each_entry(task, &tasks, list) {
+    list_for_each_entry (task, &tasks, list) {
         if (task->id == id)
             return task;
     }
@@ -138,7 +138,7 @@ task_t *get_task_by_id(tid_t id) {
 task_t *get_task_by_name(const char *name) {
     task_t *task;
 
-    list_for_each_entry(task, &tasks, list) {
+    list_for_each_entry (task, &tasks, list) {
         if (!strcmp(task->name, name))
             return task;
     }
@@ -149,7 +149,7 @@ task_t *get_task_by_name(const char *name) {
 task_t *get_task_for_cpu(unsigned int cpu) {
     task_t *task;
 
-    list_for_each_entry(task, &tasks, list) {
+    list_for_each_entry (task, &tasks, list) {
         if (task->cpu == cpu)
             return task;
     }
@@ -165,8 +165,7 @@ void schedule_task(task_t *task, unsigned int cpu) {
 
     BUG_ON(get_task_state(task) != TASK_STATE_READY);
 
-    printk("CPU[%u]: Scheduling task %s[%u]\n",
-           cpu, task->name, task->id);
+    printk("CPU[%u]: Scheduling task %s[%u]\n", cpu, task->name, task->id);
 
     task->cpu = cpu;
     set_task_state(task, TASK_STATE_SCHEDULED);
@@ -178,8 +177,7 @@ static void run_task(task_t *task) {
 
     wait_for_task_state(task, TASK_STATE_SCHEDULED);
 
-    printk("CPU[%u]: Running task %s[%u]\n",
-           task->cpu, task->name, task->id);
+    printk("CPU[%u]: Running task %s[%u]\n", task->cpu, task->name, task->id);
 
     set_task_state(task, TASK_STATE_RUNNING);
     task->func(task, task->arg);
@@ -193,20 +191,19 @@ void wait_for_all_tasks(void) {
     do {
         busy = false;
 
-        list_for_each_entry(task, &tasks, list) {
+        list_for_each_entry (task, &tasks, list) {
             if (get_task_state(task) != TASK_STATE_DONE) {
                 busy = true;
                 wait_for_task_state(task, TASK_STATE_DONE);
             }
         }
         cpu_relax();
-    } while(busy && !terminate);
+    } while (busy && !terminate);
 }
 
 void run_tasks(unsigned int cpu) {
     do {
         run_task(get_task_for_cpu(cpu));
         cpu_relax();
-    } while(!terminate);
+    } while (!terminate);
 }
-

--- a/common/setup.c
+++ b/common/setup.c
@@ -22,19 +22,19 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <apic.h>
+#include <console.h>
 #include <ktf.h>
 #include <lib.h>
-#include <page.h>
-#include <traps.h>
-#include <string.h>
-#include <setup.h>
-#include <segment.h>
-#include <console.h>
-#include <pagetable.h>
 #include <multiboot.h>
-#include <apic.h>
+#include <page.h>
+#include <pagetable.h>
 #include <percpu.h>
 #include <sched.h>
+#include <segment.h>
+#include <setup.h>
+#include <string.h>
+#include <traps.h>
 
 #include <mm/pmm.h>
 #include <mm/vmm.h>
@@ -65,15 +65,20 @@ static __always_inline void zero_bss(void) {
 }
 
 static __always_inline void zap_boot_mappings(void) {
-#if defined (__x86_64__)
-    memset(paddr_to_virt_kern(virt_to_paddr(l4_pt_entries)), 0, L4_PT_ENTRIES * sizeof(pgentry_t));
+#if defined(__x86_64__)
+    memset(paddr_to_virt_kern(virt_to_paddr(l4_pt_entries)), 0,
+           L4_PT_ENTRIES * sizeof(pgentry_t));
 #endif
-    memset(paddr_to_virt_kern(virt_to_paddr(l3_pt_entries)), 0, L3_PT_ENTRIES * sizeof(pgentry_t));
-    memset(paddr_to_virt_kern(virt_to_paddr(l2_pt_entries)), 0, L2_PT_ENTRIES * sizeof(pgentry_t));
-    memset(paddr_to_virt_kern(virt_to_paddr(l1_pt_entries)), 0, L1_PT_ENTRIES * sizeof(pgentry_t));
+    memset(paddr_to_virt_kern(virt_to_paddr(l3_pt_entries)), 0,
+           L3_PT_ENTRIES * sizeof(pgentry_t));
+    memset(paddr_to_virt_kern(virt_to_paddr(l2_pt_entries)), 0,
+           L2_PT_ENTRIES * sizeof(pgentry_t));
+    memset(paddr_to_virt_kern(virt_to_paddr(l1_pt_entries)), 0,
+           L1_PT_ENTRIES * sizeof(pgentry_t));
 }
 
-void __noreturn __text_init kernel_start(uint32_t multiboot_magic, multiboot_info_t *mbi) {
+void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
+                                         multiboot_info_t *mbi) {
     /* Zero-out BSS sections */
     zero_bss();
 
@@ -113,7 +118,7 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic, multiboot_inf
     smp_init();
 
     /* Jump from .text.init section to .text */
-    asm volatile("push %0; ret" :: "r" (&kernel_main));
+    asm volatile("push %0; ret" ::"r"(&kernel_main));
 
     UNREACHABLE();
 }

--- a/drivers/serial.c
+++ b/drivers/serial.c
@@ -29,10 +29,10 @@
 #include <drivers/serial.h>
 
 static inline void set_port_mode(io_port_t port, bool stop_bit, uint8_t width) {
-    lcr_t lcr = { 0 };
+    lcr_t lcr = {0};
 
     lcr.stop_bit = stop_bit;
-    lcr.width= width;
+    lcr.width = width;
     outb(port + UART_LCR_REG_OFFSET, lcr.reg);
 }
 
@@ -61,7 +61,7 @@ static inline bool receiver_ready(io_port_t port) {
 }
 
 void uart_init(io_port_t port, unsigned baud) {
-    mcr_t mcr = { 0 };
+    mcr_t mcr = {0};
 
     /* Disable interrupts */
     outb(port + UART_IER_REG_OFFSET, 0x00);
@@ -115,25 +115,25 @@ static int uart_puts(io_port_t port, const char *buf, size_t len) {
 
 #define SERIAL_TIMEOUT 1000 /* ~1s */
 int serial_putchar(io_port_t port, char c) {
-   unsigned retries = SERIAL_TIMEOUT;
-   int rc;
+    unsigned retries = SERIAL_TIMEOUT;
+    int rc;
 
-   do {
-       rc = uart_putc(port, c);
-       BUG_ON(rc < 0);
-   } while(rc > 0 && retries--);
+    do {
+        rc = uart_putc(port, c);
+        BUG_ON(rc < 0);
+    } while (rc > 0 && retries--);
 
-   return rc;
+    return rc;
 }
 
 int serial_write(io_port_t port, const char *buf, size_t len) {
-   unsigned retries = SERIAL_TIMEOUT;
-   int rc;
+    unsigned retries = SERIAL_TIMEOUT;
+    int rc;
 
-   do {
-       rc = uart_puts(port, buf, len);
-       BUG_ON(rc < 0);
-   } while(rc > 0 && retries--);
+    do {
+        rc = uart_puts(port, buf, len);
+        BUG_ON(rc < 0);
+    } while (rc > 0 && retries--);
 
-   return rc;
+    return rc;
 }

--- a/drivers/vga.c
+++ b/drivers/vga.c
@@ -22,10 +22,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <drivers/vga.h>
 #include <ktf.h>
 #include <page.h>
 #include <string.h>
-#include <drivers/vga.h>
 
 #define MAX_ROWS VGA_ROWS
 #define MAX_COLS (2 * VGA_COLS)
@@ -67,4 +67,3 @@ void vga_write(const char *buf, size_t len, vga_color_t color) {
 
     write_vga_buffer();
 }
-

--- a/include/console.h
+++ b/include/console.h
@@ -25,6 +25,8 @@
 #ifndef KTF_CONSOLE_H
 #define KTF_CONSOLE_H
 
+#include <ktf.h>
+
 typedef void (*console_callback_t)(const char *buf, size_t len);
 
 extern void printk(const char *fmt, ...);

--- a/include/drivers/serial.h
+++ b/include/drivers/serial.h
@@ -114,7 +114,7 @@ typedef union interrupt_enable_register ier_t;
 /* External declarations */
 
 extern void uart_init(io_port_t port, unsigned baud);
-extern int  serial_putchar(io_port_t port, char c);
-extern int  serial_write(io_port_t port, const char *buf, size_t len);
+extern int serial_putchar(io_port_t port, char c);
+extern int serial_write(io_port_t port, const char *buf, size_t len);
 
 #endif /* KTF_DRV_SERIAL_H */

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -53,11 +53,11 @@ extern unsigned long __start_bss_init[], __end_bss_init[];
 extern unsigned long __start_rmode[], __end_rmode[];
 
 struct addr_range {
-    const char *  name;
+    const char *name;
     unsigned long base;
     unsigned long flags;
-    void *        start;
-    void *        end;
+    void *start;
+    void *end;
 };
 typedef struct addr_range addr_range_t;
 
@@ -68,8 +68,8 @@ extern addr_range_t addr_ranges[];
 
 struct frame {
     struct list_head list;
-    mfn_t            mfn;
-    uint32_t         refcount;
+    mfn_t mfn;
+    uint32_t refcount;
     uint32_t : 24, order : 6, uncachable : 1, free : 1;
 };
 typedef struct frame frame_t;
@@ -81,15 +81,15 @@ typedef struct frame frame_t;
 extern void display_memory_map(void);
 
 extern addr_range_t get_memory_range(paddr_t pa);
-extern paddr_t      get_memory_range_start(paddr_t pa);
-extern paddr_t      get_memory_range_end(paddr_t pa);
+extern paddr_t get_memory_range_start(paddr_t pa);
+extern paddr_t get_memory_range_end(paddr_t pa);
 
 extern bool paddr_invalid(paddr_t pa);
 
 extern void init_pmm(void);
 
 extern mfn_t get_free_frames(unsigned int order);
-extern void  put_frame(mfn_t mfn, unsigned int order);
+extern void put_frame(mfn_t mfn, unsigned int order);
 
 extern void map_used_memory(void);
 

--- a/include/mm/vmm.h
+++ b/include/mm/vmm.h
@@ -36,7 +36,7 @@ enum gfp_flags {
 /* External definitions */
 
 extern void *get_free_pages(unsigned int order, uint32_t flags);
-extern void  put_pages(void *page, unsigned int order);
+extern void put_pages(void *page, unsigned int order);
 
 /* Static definitions */
 

--- a/include/multiboot.h
+++ b/include/multiboot.h
@@ -157,7 +157,7 @@ struct multiboot_info {
     uint32_t mods_addr;
 
     union {
-        multiboot_aout_symbol_table_t        aout_sym;
+        multiboot_aout_symbol_table_t aout_sym;
         multiboot_elf_section_header_table_t elf_sec;
     } u;
 
@@ -190,7 +190,7 @@ struct multiboot_info {
     uint32_t framebuffer_pitch;
     uint32_t framebuffer_width;
     uint32_t framebuffer_height;
-    uint8_t  framebuffer_bpp;
+    uint8_t framebuffer_bpp;
 #define MULTIBOOT_FRAMEBUFFER_TYPE_INDEXED  0
 #define MULTIBOOT_FRAMEBUFFER_TYPE_RGB      1
 #define MULTIBOOT_FRAMEBUFFER_TYPE_EGA_TEXT 2
@@ -293,7 +293,7 @@ extern void init_multiboot(multiboot_info_t *mbi, const char **cmdline);
 #include <mm/pmm.h>
 #include <page.h>
 extern unsigned mbi_get_avail_memory_ranges_num(void);
-extern int      mbi_get_avail_memory_range(unsigned index, addr_range_t *r);
-extern int      mbi_get_memory_range(paddr_t pa, addr_range_t *r);
+extern int mbi_get_avail_memory_range(unsigned index, addr_range_t *r);
+extern int mbi_get_memory_range(paddr_t pa, addr_range_t *r);
 
 #endif /* KTF_MULTIBOOT_H */

--- a/include/page.h
+++ b/include/page.h
@@ -127,7 +127,7 @@ typedef unsigned long mfn_t;
 #define PADDR_INVALID (0UL)
 #define MFN_INVALID   (0UL)
 
-static inline mfn_t   paddr_to_mfn(paddr_t pa) { return (mfn_t)(pa >> PAGE_SHIFT); }
+static inline mfn_t paddr_to_mfn(paddr_t pa) { return (mfn_t)(pa >> PAGE_SHIFT); }
 static inline paddr_t mfn_to_paddr(mfn_t mfn) { return (paddr_t)(mfn << PAGE_SHIFT); }
 
 static inline void *_paddr_to_virt(paddr_t pa, unsigned long addr_space) {

--- a/include/pagetable.h
+++ b/include/pagetable.h
@@ -26,7 +26,10 @@
 #define KTF_PAGETABLE_H
 
 #include <compiler.h>
+#include <lib.h>
 #include <page.h>
+
+#include <mm/pmm.h>
 
 #ifndef __ASSEMBLY__
 
@@ -46,10 +49,10 @@ union pte {
     struct __packed {
         unsigned int P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, D : 1, PAT : 1,
             G : 1;
-        unsigned int  IGN0 : 3;
+        unsigned int IGN0 : 3;
         unsigned long mfn : 40;
-        unsigned int  IGN1 : 7;
-        unsigned int  PKE : 4, NX : 1;
+        unsigned int IGN1 : 7;
+        unsigned int PKE : 4, NX : 1;
     };
 };
 typedef union pte pte_t;
@@ -66,10 +69,10 @@ union pde {
         unsigned int : 12;
     };
     struct __packed {
-        unsigned int  P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, IGN0 : 1, PS : 1;
-        unsigned int  IGN1 : 4;
+        unsigned int P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, IGN0 : 1, PS : 1;
+        unsigned int IGN1 : 4;
         unsigned long mfn : 40;
-        unsigned int  IGN2 : 11, NX : 1;
+        unsigned int IGN2 : 11, NX : 1;
     };
 };
 typedef union pde pde_t;
@@ -86,10 +89,10 @@ union pdpe {
         unsigned int : 12;
     };
     struct __packed {
-        unsigned int  P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, IGN0 : 1, PS : 1;
-        unsigned int  IGN1 : 4;
+        unsigned int P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, IGN0 : 1, PS : 1;
+        unsigned int IGN1 : 4;
         unsigned long mfn : 40;
-        unsigned int  IGN2 : 11, NX : 1;
+        unsigned int IGN2 : 11, NX : 1;
     };
 };
 typedef union pdpe pdpe_t;
@@ -107,10 +110,10 @@ union pml4 {
         unsigned int : 12;
     };
     struct __packed {
-        unsigned int  P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, IGN0 : 1, Z : 1;
-        unsigned int  IGN1 : 4;
+        unsigned int P : 1, RW : 1, US : 1, PWT : 1, PCD : 1, A : 1, IGN0 : 1, Z : 1;
+        unsigned int IGN1 : 4;
         unsigned long mfn : 40;
-        unsigned int  IGN2 : 11, NX : 1;
+        unsigned int IGN2 : 11, NX : 1;
     };
 };
 typedef union pml4 pml4_t;
@@ -123,9 +126,9 @@ union cr3 {
         unsigned int : 12;
     };
     struct __packed {
-        unsigned int  IGN0 : 3, PWT : 1, PCD : 1, IGN1 : 7;
+        unsigned int IGN0 : 3, PWT : 1, PCD : 1, IGN1 : 7;
         unsigned long mfn : 40;
-        unsigned int  RSVD : 12;
+        unsigned int RSVD : 12;
     };
     struct __packed {
         unsigned int PCID : 12;
@@ -241,8 +244,8 @@ static inline void set_pgentry(pgentry_t *e, mfn_t mfn, unsigned long flags) {
 
 /* External declarations */
 
-extern pte_t  l1_pt_entries[L1_PT_ENTRIES];
-extern pde_t  l2_pt_entries[L2_PT_ENTRIES];
+extern pte_t l1_pt_entries[L1_PT_ENTRIES];
+extern pde_t l2_pt_entries[L2_PT_ENTRIES];
 extern pdpe_t l3_pt_entries[L3_PT_ENTRIES];
 #if defined(__x86_64__)
 extern pml4_t l4_pt_entries[L4_PT_ENTRIES];

--- a/include/percpu.h
+++ b/include/percpu.h
@@ -31,15 +31,15 @@
 #include <page.h>
 
 struct percpu {
-    list_head_t  list;
+    list_head_t list;
     unsigned int id : 8, apic_id : 8, enabled : 1, bsp : 1, family : 4, model : 4,
         stepping : 4;
 
     idt_entry_t *idt __aligned(16);
-    idt_ptr_t        idt_ptr;
+    idt_ptr_t idt_ptr;
 
     gdt_desc_t gdt[NR_GDT_ENTRIES] __aligned(16);
-    gdt_ptr_t  gdt_ptr;
+    gdt_ptr_t gdt_ptr;
 
     x86_tss_t tss __aligned(16);
 #if defined(__i386__)
@@ -47,13 +47,13 @@ struct percpu {
 #endif
 
     unsigned long ret2kern_sp;
-    void *        user_stack;
+    void *user_stack;
 } __aligned(PAGE_SIZE);
 typedef struct percpu percpu_t;
 
 /* External declarations */
 
-extern void      init_percpu(void);
+extern void init_percpu(void);
 extern percpu_t *get_percpu_page(unsigned int cpu);
 
 #endif /* KTF_PERCPU_H */

--- a/include/processor.h
+++ b/include/processor.h
@@ -239,10 +239,10 @@ struct cpu_regs {
 
     /* Hardware exception */
     x86_reg_t _ASM_IP;
-    uint16_t  cs, _pad_cs[3];
+    uint16_t cs, _pad_cs[3];
     x86_reg_t _ASM_FLAGS;
     x86_reg_t _ASM_SP;
-    uint16_t  ss, _pad_ss[3];
+    uint16_t ss, _pad_ss[3];
 };
 typedef struct cpu_regs cpu_regs_t;
 

--- a/include/sched.h
+++ b/include/sched.h
@@ -46,14 +46,14 @@ typedef unsigned int tid_t;
 struct task {
     list_head_t list;
 
-    tid_t        id;
+    tid_t id;
     task_state_t state;
 
     unsigned int cpu;
 
     const char *name;
     task_func_t func;
-    void *      arg;
+    void *arg;
 
     unsigned long result;
 } __aligned(PAGE_SIZE);
@@ -61,13 +61,13 @@ typedef struct task task_t;
 
 /* External declarations */
 
-extern void    init_tasks(void);
+extern void init_tasks(void);
 extern task_t *get_task_by_id(tid_t id);
 extern task_t *get_task_by_name(const char *name);
 extern task_t *get_task_for_cpu(unsigned int cpu);
 extern task_t *new_task(const char *name, task_func_t func, void *arg);
-extern void    schedule_task(task_t *task, unsigned int cpu);
-extern void    run_tasks(unsigned int cpu);
-extern void    wait_for_all_tasks(void);
+extern void schedule_task(task_t *task, unsigned int cpu);
+extern void run_tasks(unsigned int cpu);
+extern void wait_for_all_tasks(void);
 
 #endif /* KTF_SCHED_H */

--- a/include/segment.h
+++ b/include/segment.h
@@ -107,7 +107,7 @@ struct __packed x86_segment_desc {
         struct __packed {
             uint16_t limit_lo;
             uint16_t base_lo;
-            uint8_t  base_mi;
+            uint8_t base_mi;
             struct __packed {
                 uint8_t A : 1, RW : 1, DC : 1, E : 1, S : 1, DPL : 2, P : 1;
             };
@@ -154,11 +154,11 @@ struct __packed x86_gate32 {
             uint32_t lo, hi;
         };
         struct {
-            uint16_t     offset_lo;
-            uint16_t     selector;
-            uint8_t      rsvd;
+            uint16_t offset_lo;
+            uint16_t selector;
+            uint8_t rsvd;
             unsigned int type : 4, s : 1, dpl : 2, p : 1;
-            uint16_t     offset_hi;
+            uint16_t offset_hi;
         };
     };
 };
@@ -187,13 +187,13 @@ struct __packed x86_gate64 {
             uint64_t lo, hi;
         };
         struct {
-            uint16_t     offset_lo;
-            uint16_t     selector;
+            uint16_t offset_lo;
+            uint16_t selector;
             unsigned int ist : 3, rsvd0 : 5;
             unsigned int type : 4, s : 1, dpl : 2, p : 1;
-            uint16_t     offset_mi;
-            uint32_t     offset_hi;
-            uint32_t     rsvd1;
+            uint16_t offset_mi;
+            uint32_t offset_hi;
+            uint32_t rsvd1;
         };
     };
 };
@@ -293,7 +293,7 @@ static inline void set_intr_gate(struct x86_gate64 *gate, uint16_t selector,
 #endif
 
 extern idt_entry_t idt[256];
-extern idt_ptr_t   idt_ptr;
+extern idt_ptr_t idt_ptr;
 #endif /* __ASSEMBLY__ */
 
 #endif /* KTF_SEGMENT_H */

--- a/include/smp/mptables.h
+++ b/include/smp/mptables.h
@@ -33,12 +33,12 @@
 struct mpf {
     uint32_t signature;
     uint32_t mpc_base;
-    uint8_t  length;
-    uint8_t  spec_rev;
-    uint8_t  checksum;
-    uint8_t  mpc_type;
-    uint8_t  rsvd0 : 6, imcrp : 1;
-    uint8_t  rsvd1[3];
+    uint8_t length;
+    uint8_t spec_rev;
+    uint8_t checksum;
+    uint8_t mpc_type;
+    uint8_t rsvd0 : 6, imcrp : 1;
+    uint8_t rsvd1[3];
 } __packed;
 typedef struct mpf mpf_t;
 
@@ -54,19 +54,19 @@ enum mpc_entry_type {
 typedef enum mpc_entry_type mpc_entry_type_t;
 
 struct mpc_hdr {
-    uint32_t   signature;
-    uint16_t   length;
-    uint8_t    spec_rev;
-    uint8_t    checksum;
+    uint32_t signature;
+    uint16_t length;
+    uint8_t spec_rev;
+    uint8_t checksum;
     const char oem_id[8];
     const char product_id[12];
-    uint32_t   oem_tlb_ptr;
-    uint16_t   oem_tlb_size;
-    uint16_t   entry_count;
-    uint32_t   lapic_base;
-    uint16_t   ext_length;
-    uint8_t    ext_checksum;
-    uint8_t    rsvd;
+    uint32_t oem_tlb_ptr;
+    uint16_t oem_tlb_size;
+    uint16_t entry_count;
+    uint32_t lapic_base;
+    uint16_t ext_length;
+    uint8_t ext_checksum;
+    uint8_t rsvd;
 } __packed;
 typedef struct mpc_hdr mpc_hdr_t;
 

--- a/include/smp/smp.h
+++ b/include/smp/smp.h
@@ -33,7 +33,7 @@
 
 /* External declarations */
 
-extern void     smp_init(void);
+extern void smp_init(void);
 extern unsigned get_nr_cpus(void);
 
 /* Static declarations */

--- a/include/string.h
+++ b/include/string.h
@@ -105,8 +105,8 @@ static inline void *memcpy(void *d, void *s, size_t n) {
 }
 
 static inline int memcmp(const void *m1, const void *m2, size_t n) {
-    const uint8_t *  _m1 = m1;
-    const uint8_t *  _m2 = m2;
+    const uint8_t *_m1 = m1;
+    const uint8_t *_m2 = m2;
     register uint8_t res = 0;
 
     if (m1 == m2)
@@ -165,8 +165,8 @@ static inline int strncmp(const char *s1, const char *s2, size_t n) {
 /* External declarations */
 
 extern unsigned long strtoul(const char *nptr, char **endptr, int base);
-extern long          strtol(const char *nptr, char **endptr, int base);
-extern int           vsnprintf(char *str, size_t size, char const *fmt, va_list ap);
-extern void          snprintf(char *buf, size_t size, const char *fmt, ...);
+extern long strtol(const char *nptr, char **endptr, int base);
+extern int vsnprintf(char *str, size_t size, char const *fmt, va_list ap);
+extern void snprintf(char *buf, size_t size, const char *fmt, ...);
 
 #endif /* KTF_STRING_H */

--- a/lib/lib.c
+++ b/lib/lib.c
@@ -28,7 +28,7 @@
 void __noreturn halt(void) {
     cli();
 
-    while(1) {
+    while (1) {
         hlt();
         pause();
     }

--- a/lib/string.c
+++ b/lib/string.c
@@ -38,6 +38,8 @@
 #include <ktf.h>
 #include <string.h>
 
+/* clang-format off */
+
 /*
  * Convert a string to an unsigned long integer.
  *
@@ -497,3 +499,4 @@ void snprintf(char *buf, size_t size, const char *fmt, ...) {
     vsnprintf(buf, size, fmt, args);
     va_end(args);
 }
+/* clang-format on */

--- a/smp/smp.c
+++ b/smp/smp.c
@@ -22,19 +22,19 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <apic.h>
+#include <console.h>
 #include <ktf.h>
 #include <lib.h>
-#include <console.h>
-#include <setup.h>
-#include <apic.h>
-#include <traps.h>
 #include <percpu.h>
 #include <sched.h>
+#include <setup.h>
+#include <traps.h>
 
 #include <mm/vmm.h>
 
-#include <smp/smp.h>
 #include <smp/mptables.h>
+#include <smp/smp.h>
 
 extern void ap_start(void);
 
@@ -53,7 +53,7 @@ void __noreturn ap_startup(void) {
 
     run_tasks(smp_processor_id());
 
-    while(true)
+    while (true)
         halt();
 
     UNREACHABLE();
@@ -84,7 +84,7 @@ static void boot_cpu(unsigned int cpu) {
     apic_icr_write(icr | (APIC_DM_STARTUP | GET_SIPI_VECTOR(ap_start)));
     apic_wait_ready();
 
-    while(!ap_callin)
+    while (!ap_callin)
         cpu_relax();
 
     dprintk("AP: %u Done \n", cpu);
@@ -104,6 +104,4 @@ void smp_init(void) {
         boot_cpu(i);
 }
 
-unsigned get_nr_cpus(void) {
-    return nr_cpus;
-}
+unsigned get_nr_cpus(void) { return nr_cpus; }

--- a/tests/test.c
+++ b/tests/test.c
@@ -22,13 +22,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <ktf.h>
 #include <console.h>
+#include <ktf.h>
 #include <sched.h>
 
-static int __user_text func(void *arg) {
-    return 0;
-}
+static int __user_text func(void *arg) { return 0; }
 
 void test_main(void) {
     printk("\nTest:\n");


### PR DESCRIPTION
This change will hopefully make the style checking workflow happy.

Author: Pawel Wieczorkiewicz <wipawel@amazon.de>
Date:   Sun Aug 16 13:39:12 2020 +0200

    README: add clang-format action workflow instructions

    Explains how to run and apply action workflow locally to avoid
    breaking style.

    Also minor README changes.

    Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

Author: Pawel Wieczorkiewicz <wipawel@amazon.de>
Date:   Sun Aug 16 13:04:46 2020 +0200

    style: yet another style unifying change

    * Set AlignConsecutiveDeclarations to false to disable declarations
      alignment.
    * Disable clang-format for some definitions and declaration that I
      find more readable now.

    The modifications are a result of running the GitHub's clang-format
    action workflow locally and patch all outstanding files:

    docker run --rm --workdir /src -v $(pwd):/src clang-format-lint \
        --clang-format-executable /clang-format/clang-format10 -r   \
        --exclude .git $(find . -name \*.c -or -name \*.h -print) | patch -p1

    Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

Author: Pawel Wieczorkiewicz <wipawel@amazon.de>
Date:   Thu Aug 13 11:47:49 2020 +0200

    style: disable clang-format in string.c file

    The string.c file has been imported into this repo as-is with the
    original license and structure.

    We should not modify it without a good reason (e.g. bug fixing).

    Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
