### PR TITLE
sched: no two tasks can share the same name

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -184,6 +184,12 @@ static inline const char *string_trim_whitspace(const char *s) {
     return s;
 }
 
+static inline int string_empty(const char *s) { return !s || *s == '\0'; }
+
+static inline int string_equal(const char *s1, const char *s2) {
+    return (!s1 || !s2) ? s1 == s2 : !strcmp(s1, s2);
+}
+
 /* External declarations */
 
 extern unsigned long strtoul(const char *nptr, char **endptr, int base);


### PR DESCRIPTION
Signed-off-by: Daniele Ahmed <ahmeddan @ amazon com>

*Issue #, if available:*

*Description of changes:*
Forbid tasks sharing names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
