### PR TITLE
pmm, pagetables: automatically map all PT frames

### DIFF
--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -92,6 +92,7 @@ static inline void dump_page_table(void *table, int level) {
 void dump_pagetables(void) {
     printk("\nPage Tables:\n");
     printk("CR3: paddr: 0x%lx\n", cr3.paddr);
+    map_used_memory();
     dump_page_table(get_l4_table(), 4);
 }
 

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -70,7 +70,7 @@ struct frame {
     struct list_head list;
     mfn_t mfn;
     uint32_t refcount;
-    uint32_t : 24, order : 6, uncachable : 1, free : 1;
+    uint32_t : 23, mapped : 1, order : 6, uncachable : 1, free : 1;
 };
 typedef struct frame frame_t;
 

--- a/mm/pmm.c
+++ b/mm/pmm.c
@@ -293,7 +293,11 @@ void map_used_memory(void) {
     frame_t *frame;
 
     for_each_order (order) {
-        list_for_each_entry (frame, &busy_frames[order], list)
-            kmap(frame->mfn, order, L1_PROT);
+        list_for_each_entry (frame, &busy_frames[order], list) {
+            if (!frame->mapped) {
+                kmap(frame->mfn, order, L1_PROT);
+                frame->mapped = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
* PMM
  - Add physical frame flag: mapped
  - map_used_memory() might be called multiple to map in newly
    allocated memory
    Use new mapped flag to skip already mapped ones.

* Pagetables:
  - Always map used physical frames when dumping pagetables

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

*Issue #35 *


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
