### PR TITLE
Makefile: add style target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ CFLAGS  += -Werror
 -include Makeconf.local
 
 SOURCES     := $(shell find . -name \*.c)
+HEADERS     := $(shell find . -name \*.h)
 ASM_SOURCES := $(shell find . -name \*.S)
 LINK_SCRIPT := $(shell find . -name \*.ld)
 
@@ -141,6 +142,12 @@ cscope:
 	@echo "CSCOPE"
 	@ $(all_sources) > cscope.files
 	@ cscope -b -q -k
+
+.PHONY: style
+style:
+	@echo "STYLE"
+	@ docker run --rm --workdir /src -v $(PWD):/src clang-format-lint --clang-format-executable /clang-format/clang-format10 \
+          -r $(SOURCES) $(HEADERS) | grep -v -E '^Processing [0-9]* files:' | patch -s -p1 ||:
 
 DOCKERFILE  := $(shell find $(ROOT) -type f -name Dockerfile)
 DOCKERIMAGE := "ktf:build"

--- a/README.md
+++ b/README.md
@@ -138,9 +138,7 @@ This has to be done only once.
 #### Patch your files
 
 ```bash
-for ext in c h; do
-    docker run --rm --workdir /src -v $(pwd):/src clang-format-lint --clang-format-executable /clang-format/clang-format10 -r --exclude .git $(find . -name \*.$ext -print) | patch -p1
-done
+make style
 ```
 
 ## Credits and Attributions


### PR DESCRIPTION
It automatically runs and applies clang-format style checker locally.
The container needs to be built once (see: README.md)

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
