### PR TITLE
Add symbols handling and callstack printing

### DIFF
--- a/common/symbols.c
+++ b/common/symbols.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <ktf.h>
+#include <lib.h>
+#include <mm/pmm.h>
+#include <string.h>
+#include <symbols.h>
+
+static inline bool is_symbol_address(const void *addr, unsigned index) {
+    return addr >= symbol_addresses[index] &&
+           addr < symbol_addresses[index] + symbol_sizes[index];
+}
+
+/* This function uses binary search and requires symbol_addresses[] to be sorted */
+static long symbol_index_by_address(const void *addr) {
+    unsigned left, right;
+
+    if (!in_text_section(addr))
+        return -1;
+
+    left = 0;
+    right = symbol_count - 1;
+
+    while (left != right) {
+        unsigned mid = (left + right) / 2;
+
+        if (is_symbol_address(addr, mid))
+            return mid;
+        else if (addr < symbol_addresses[mid])
+            right = mid;
+        else
+            left = mid;
+    }
+
+    if (is_symbol_address(addr, left))
+        return left;
+
+    return -1;
+}
+
+static long symbol_index_by_name(const char *name) {
+    /* FIXME: this probably should use better search algorithm */
+    for (unsigned int i = 0; i < symbol_count; i++) {
+        if (!strcmp(symbol_names_ptr[i], name))
+            return i;
+    }
+
+    return -1;
+}
+
+const char *symbol_name(const void *addr) {
+    long index = symbol_index_by_address(addr);
+
+    return index < 0 ? NULL : symbol_names_ptr[index];
+}
+
+void *symbol_address(const char *name) {
+    long index = symbol_index_by_name(name);
+
+    return index < 0 ? NULL : symbol_addresses[index];
+}
+
+void print_symbol(const void *addr) {
+    long index = symbol_index_by_address(addr);
+
+    if (index < 0)
+        return;
+
+    printk("0x%016lx: %s + <0x%lx> [0x%x]\n", _ul(addr), symbol_names_ptr[index],
+           _ul(addr - symbol_addresses[index]), symbol_sizes[index]);
+}

--- a/include/arch/x86/traps.h
+++ b/include/arch/x86/traps.h
@@ -35,6 +35,9 @@
 extern void init_traps(unsigned int cpu);
 extern void init_boot_traps(void);
 
+extern void print_callstack(const void *sp, const void *ip);
+extern void do_exception(struct cpu_regs *regs);
+
 #endif /* __ASSEMBLY__ */
 
 #endif /* TRAPS_TRAPS_H */

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -54,6 +54,7 @@
 #define __noreturn   __attribute__((__noreturn__))
 #define __packed     __attribute__((__packed__))
 #define __used       __attribute__((__used__))
+#define __weak       __attribute__((__weak__))
 #define __noinline   __attribute__((__noinline__))
 #define __section(s) __attribute__((__section__(s)))
 

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -55,6 +55,8 @@ extern unsigned long __start_rmode[], __end_rmode[];
 
 extern struct ktf_param __start_cmdline[], __end_cmdline[];
 
+extern unsigned long __weak __start_symbols[], __end_symbols[];
+
 struct addr_range {
     const char *name;
     unsigned long base;

--- a/include/symbols.h
+++ b/include/symbols.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef KTF_SYMBOLS_H
+#define KTF_SYMBOLS_H
+
+extern unsigned int symbol_count __attribute__((weak));
+extern void *symbol_addresses[] __attribute__((weak));
+extern unsigned int symbol_sizes[] __attribute__((weak));
+extern const char *symbol_names_ptr[] __attribute__((weak));
+
+/* External declarations */
+
+extern const char *symbol_name(const void *addr);
+extern void *symbol_address(const char *name);
+
+extern void print_symbol(const void *addr);
+
+#endif /* KTF_SYMBOLS_H */

--- a/mm/pmm.c
+++ b/mm/pmm.c
@@ -79,6 +79,7 @@ addr_range_t addr_ranges[] = {
     KERNEL_RANGE( ".data",      L1_PROT,         __start_data,      __end_data      ),
     KERNEL_RANGE( ".bss",       L1_PROT,         __start_bss,       __end_bss       ),
     KERNEL_RANGE( ".rodata",    L1_PROT_RO,      __start_rodata,    __end_rodata    ),
+    KERNEL_RANGE( ".symbols",   L1_PROT_RO,      __start_symbols,   __end_symbols   ),
     /* clang-format on */
 
     {0x0} /* NULL array terminator */

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -4,6 +4,6 @@ FROM ubuntu:20.04
 RUN apt-get update -y
 RUN apt-get install -y gcc make xorriso qemu-utils
 # grub is a bit special in containers
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install grub2
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install grub2 python
 
 CMD ["/bin/bash"]

--- a/tools/symbols/symbols.py
+++ b/tools/symbols/symbols.py
@@ -1,0 +1,154 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+ Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ All Rights Reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+import argparse
+import fileinput
+import struct
+import sys
+
+
+header_files = ["asm-macros.h"]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Generate assembly file with symbols information')
+    parser.add_argument(
+        '-s', '--section-name',
+        dest='section_name',
+        default='symbols',
+        type=str,
+        help='Name of a section holding symbols'
+    )
+    parser.add_argument(
+        '-o', '--output',
+        dest='output_file',
+        default='symbols.S',
+        type=str,
+        help='Name of the output assembly file'
+    )
+
+    return parser.parse_args()
+
+
+def add_headers(output, headers):
+    output_str = "\n".join(["#include <%s>" % h for h in headers])
+    output.write(output_str)
+
+
+def add_type_detection(output):
+    output_str = """
+# if defined(__x86_64__)
+# define TYPE .quad
+# else
+# define TYPE .long
+# endif
+    """
+    output.write(output_str)
+
+
+def add_section_start(output, name, align=8):
+    output_str = "SECTION(.%s, \"a\", %d)\n" % (name, align)
+    output_str += "GLOBAL(__start_%s)\n\n" % name
+    output.write(output_str)
+
+
+def add_section_end(output, name, align=0x1000):
+    output_str = ".align 0x%x\n" % align
+    output_str += "GLOBAL(__end_%s)\n" % name
+    output.write(output_str)
+
+
+def add_object(output, name, content):
+    output_str = "GLOBAL(%s)\n" % name
+    output_str += "%s\n" % content
+    output_str += "END_OBJECT(%s)\n" % name
+    output.write(output_str)
+
+
+def main():
+    symbols_array = []
+    symbol_names = []
+    symbol_addresses = []
+    symbol_sizes = []
+
+    args = parse_args()
+
+    for line in fileinput.input():
+        sym = line.split()
+
+        # Skip symbols without size
+        if len(sym) < 4:
+            continue
+
+        symbols_array.append(sym)
+
+    symbols_array.sort(key=lambda x: int(x[2], 16))
+
+    for sym in symbols_array:
+        symbol_names.append(sym[0])
+        symbol_addresses.append(int(sym[2], 16))
+        symbol_sizes.append(int(sym[3], 16))
+
+    if len(symbol_addresses) != len(symbol_names) or len(symbol_addresses) != len(symbol_sizes):
+        print("Input parsing failed. Incorrect number of fields: symbol_addresses=%u, symbol_names=%u, symbol_sizes=%u\n" % (
+            symbol_addresses, symbol_names, symbol_sizes))
+        return 1
+
+    with open(args.output_file, "w") as output:
+        add_headers(output, header_files)
+        add_type_detection(output)
+
+        add_section_start(output, args.section_name)
+
+        output_str = '\n'.join(['TYPE 0x%lx' % x for x in symbol_addresses])
+        add_object(output, "symbol_addresses", output_str)
+
+        output_str = '\n'.join(['.long 0x%x' % x for x in symbol_sizes])
+        add_object(output, "symbol_sizes", output_str)
+
+        output_str = '\n'.join(['.ascii "%s"\n.byte 0x0' %
+                                x for x in symbol_names])
+        add_object(output, "symbol_names", output_str)
+
+        output_str = ""
+        current_len = 0
+        for name in symbol_names:
+            output_str += "TYPE symbol_names + 0x%lx\n" % current_len
+            current_len += len(name) + 1
+        add_object(output, "symbol_names_ptr", output_str)
+
+        add_object(output, "symbol_count", '.long 0x%x' %
+                   len(symbol_addresses))
+
+        add_section_end(output, args.section_name)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
*Issue #16 *

*Description of changes:*

Add basic symbols generation infrastructure. Get symbols using `nm` out of linked kernel64.bin and process it using `tools/symbols/symbols.py` into an assembly file. The symbols information is stored in symbol_addresses[], symbol_names[], symbol_names_ptr[] and symbol_sizes[] arrays as part of `.symbols` section. The assembly file is compiled and linked with the kernel64.bin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
