### PR TITLE
LGTM: exclude short-global-name check

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,3 @@
 queries:
 - exclude: cpp/fixme-comment
-
+- exclude: cpp/short-global-name


### PR DESCRIPTION
Recommendations like 'Poor global variable name 'idt'. Prefer longer, descriptive names for globals (eg. kMyGlobalConstant, not foo).' are clearly not applicable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
