### PR TITLE
Implement basic boot command line parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cscope.*
 *.iso
 *.img
 Makeconf.local
+.DS_Store

--- a/arch/x86/link.ld
+++ b/arch/x86/link.ld
@@ -145,6 +145,9 @@ SECTIONS
         . = ALIGN(4K);
         __start_data = .;
             *(.data)
+        __start_cmdline = .;
+            *(.cmdline)
+        __end_cmdline = .;
         . = ALIGN(4K);
         __end_data = .;
     } :kernel

--- a/common/setup.c
+++ b/common/setup.c
@@ -24,6 +24,7 @@
  */
 #include <acpi.h>
 #include <apic.h>
+#include <cmdline.h>
 #include <console.h>
 #include <ktf.h>
 #include <lib.h>
@@ -44,11 +45,77 @@
 #include <drivers/serial.h>
 #include <slab.h>
 
-bool opt_debug;
+bool opt_debug = false;
+bool_cmd("debug", opt_debug);
 
 io_port_t com_ports[2];
 
 const char *kernel_cmdline;
+
+static __text_init int parse_bool(const char *s) {
+    if (!strcmp("no", s) || !strcmp("off", s) || !strcmp("false", s) ||
+        !strcmp("disable", s) || !strcmp("0", s))
+        return 0;
+
+    if (!strcmp("yes", s) || !strcmp("on", s) || !strcmp("true", s) ||
+        !strcmp("enable", s) || !strcmp("1", s))
+        return 1;
+
+    return -1;
+}
+
+void __text_init cmdline_parse(const char *cmdline) {
+    static __bss_init char opt[PAGE_SIZE];
+    char *optval, *optkey, *q;
+    const char *p = cmdline;
+    struct ktf_param *param;
+
+    if (cmdline == NULL)
+        return;
+
+    for (;;) {
+        p = string_trim_whitspace(p);
+
+        if (iseostr(*p))
+            break;
+
+        q = optkey = opt;
+        while ((!isspace(*p)) && (!iseostr(*p))) {
+            ASSERT(_ul(q - opt) < sizeof(opt) - 1);
+            *q++ = *p++;
+        }
+        *q = '\0';
+
+        /* split on '=' */
+        optval = strchr(opt, '=');
+        if (optval != NULL)
+            *optval++ = '\0';
+        else
+            /* assume a bool later */
+            optval = opt;
+
+        for (param = __start_cmdline; param < __end_cmdline; param++) {
+            if (strcmp(param->name, optkey))
+                continue;
+
+            switch (param->type) {
+            case STRING:
+                strcpy(param->var, optval);
+                break;
+            case ULONG:
+                *(unsigned long *) param->var = strtoul(optval, NULL, 0);
+                break;
+            case BOOL:
+                *(bool *) param->var =
+                    !!parse_bool(!strcmp(optval, optkey) ? "1" : optval);
+                break;
+            default:
+                panic("Unkown cmdline type detected...");
+                break;
+            }
+        }
+    }
+}
 
 static void init_console(void) {
     get_com_ports();
@@ -94,6 +161,9 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
         /* Indentity mapping is still on, so fill in multiboot structures */
         init_multiboot(mbi, &kernel_cmdline);
     }
+
+    /* Parse commandline parameters */
+    cmdline_parse(kernel_cmdline);
 
     /* Initialize Physical Memory Manager */
     init_pmm();

--- a/grub/boot/grub/grub-test.cfg
+++ b/grub/boot/grub/grub-test.cfg
@@ -1,0 +1,10 @@
+set timeout=0
+set default=0
+serial --speed=115200 --word=8 --parity=no --stop=1
+terminal_input --append serial
+terminal_output --append serial
+
+menuentry "kernel64" {
+   multiboot /boot/kernel64.bin      integer=42   boolean=1   string=foo booleantwo
+   boot
+}

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -78,6 +78,8 @@
 #define __user_data __section(".data.user")
 #define __user_bss  __section(".bss.user")
 
+#define __cmdline __section(".cmdline")
+
 #define barrier()      asm volatile("" ::: "memory")
 #define ACCESS_ONCE(x) (*(volatile typeof(x) *) &(x))
 

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -34,6 +34,7 @@
 #define BIOS_ROM_ADDR_START 0xF0000
 
 #ifndef __ASSEMBLY__
+#include <cmdline.h>
 #include <list.h>
 #include <page.h>
 
@@ -51,6 +52,8 @@ extern unsigned long __start_data_init[], __end_data_init[];
 extern unsigned long __start_bss_init[], __end_bss_init[];
 
 extern unsigned long __start_rmode[], __end_rmode[];
+
+extern struct ktf_param __start_cmdline[], __end_cmdline[];
 
 struct addr_range {
     const char *name;

--- a/include/string.h
+++ b/include/string.h
@@ -177,6 +177,13 @@ static inline int strncmp(const char *s1, const char *s2, size_t n) {
     return res;
 }
 
+static inline const char *string_trim_whitspace(const char *s) {
+    while (isspace(*s))
+        s++;
+
+    return s;
+}
+
 /* External declarations */
 
 extern unsigned long strtoul(const char *nptr, char **endptr, int base);

--- a/include/string.h
+++ b/include/string.h
@@ -148,6 +148,19 @@ static inline int strcmp(const char *s1, const char *s2) {
     return res;
 }
 
+static inline char *strchr(const char *s, int c) {
+    if (NULL == s)
+        return NULL;
+
+    while (*s != (char) c) {
+        if ('\0' == *s)
+            return NULL;
+        s++;
+    }
+
+    return (char *) s;
+}
+
 static inline int strncmp(const char *s1, const char *s2, size_t n) {
     register char res;
 

--- a/include/string.h
+++ b/include/string.h
@@ -28,6 +28,8 @@
 
 static inline __used int isspace(int c) { return c == ' ' || c == '\t'; }
 
+static inline __used int iseostr(int c) { return c == '\0'; }
+
 static inline __used int isdigit(int c) { return c >= '0' && c <= '9'; }
 
 static inline __used int isxdigit(int c) {

--- a/tests/test.c
+++ b/tests/test.c
@@ -26,12 +26,61 @@
 #include <ktf.h>
 #include <sched.h>
 
+#ifdef KTF_UNIT_TEST
+#include <cmdline.h>
+#include <string.h>
+
+extern char *kernel_cmdline;
+
+static char opt_string[4];
+string_cmd("string", opt_string);
+
+static unsigned long opt_ulong;
+ulong_cmd("integer", opt_ulong);
+
+static bool opt_bool = 0;
+bool_cmd("boolean", opt_bool);
+
+static bool opt_booltwo = 0;
+bool_cmd("booleantwo", opt_booltwo);
+#endif
+
 static int __user_text func(void *arg) { return 0; }
 
 void test_main(void) {
     printk("\nTest:\n");
 
     usermode_call(func, NULL);
+
+#ifdef KTF_UNIT_TEST
+    printk("\nLet the UNITTESTs begin\n");
+    printk("Commandline parsing: %s\n", kernel_cmdline);
+
+    if (strcmp(opt_string, "foo")) {
+        printk("String parameter opt_string != foo: %s\n", opt_string);
+        BUG();
+    }
+    else {
+        printk("String parameter parsing works!\n");
+    }
+
+    if (opt_ulong != 42) {
+        printk("Integer parameter opt_ulong != 42: %d\n", opt_ulong);
+        BUG();
+    }
+    else {
+        printk("Integer parameter parsing works!\n");
+    }
+
+    if (!opt_bool || !opt_booltwo) {
+        printk("Boolean parameter opt_bool != true: %d\n", opt_bool);
+        printk("Boolean parameter opt_booltwo != true: %d\n", opt_booltwo);
+        BUG();
+    }
+    else {
+        printk("Boolean parameter parsing works!\n");
+    }
+#endif
 
     wait_for_all_tasks();
 


### PR DESCRIPTION
*Issue #, if available:* #9 

*Description of changes:*

This series is adding basic commandline parsing capabilities to KTF.

Testing done:

- normal build and run in qemu on Mac:
```
$ make clean boot
CLEAN
Creating docker image
[...]
Physical Memory Map
REGION: [0x0000000000000000 - 0x000000000009fc00] Available
REGION: [0x000000000009fc00 - 0x00000000000a0000] Reserved
REGION: [0x00000000000f0000 - 0x0000000000100000] Reserved
REGION: [0x0000000000100000 - 0x00000000bffdf000] Available
REGION: [0x00000000bffdf000 - 0x00000000c0000000] Reserved
REGION: [0x00000000fffc0000 - 0x0000000100000000] Reserved
REGION: [0x0000000100000000 - 0x0000000240000000] Available

Test:
Test done
All tasks done.
```

- Unittesting for commandline parsing enabled:
```
$ UNITTEST=1 make clean boot
CLEAN
Creating docker image
[...]
REGION: [0x00000000bffdf000 - 0x00000000c0000000] Reserved
REGION: [0x00000000fffc0000 - 0x0000000100000000] Reserved
REGION: [0x0000000100000000 - 0x0000000240000000] Available

Test:

Let the UNITTESTs begin
Commandline parsing: integer=42 boolean=1 string=foo booleantwo
String parameter parsing works!
Integer parameter parsing works!
Boolean parameter parsing works!
Test done
All tasks done.
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
