### PR TITLE
Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,4 +182,4 @@ dockerimage:
 .PHONY: docker%
 docker%: dockerimage
 	@echo "running target '$(strip $(subst :,, $*))' in docker"
-	@ docker run -it -e UNITTEST=$(UNITTEST) -v $(PWD):$(PWD) -w $(PWD) $(DOCKERIMAGE) bash -c "make -j $(strip $(subst :,, $*))"
+	@ docker run -it -e UNITTEST=$(UNITTEST) -v $(PWD):$(PWD)$(DOCKER_MOUNT_OPTS) -w $(PWD) $(DOCKERIMAGE) bash -c "make -j $(strip $(subst :,, $*))"

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ ISO_FILE := boot.iso
 ifneq ($(SYSTEM), LINUX)
 $(ISO_FILE): dockerboot.iso
 else
-$(ISO_FILE): all
+$(ISO_FILE): $(TARGET)
 	@echo "GEN ISO" $(ISO_FILE)
 	@ $(GRUB_FILE) --is-x86-multiboot $(TARGET) || { echo "Multiboot not supported"; exit 1; }
 	@ cp $(TARGET) grub/boot/
@@ -185,10 +185,7 @@ endif
 dockerimage:
 	@echo "Creating docker image"
 	@ docker build -t $(DOCKERIMAGE) -f $(DOCKERFILE) \
-		--build-arg USER_ID=$$(id -u) \
-		--build-arg GROUP_ID=$$(id -g) \
-		--build-arg USER=$$USER \
-		.
+		$(DOCKER_BUILD_ARGS) .
 
 .PHONY: docker%
 docker%: dockerimage

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ GRUB_FILE := grub2-file
 GRUB_MKIMAGE := grub2-mkimage
 GRUB_MODULES += normal
 QEMU_BIN := qemu-kvm
+DOCKER_MOUNT_OPTS := :Z
 endif
 ```
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,9 +1,20 @@
 FROM ubuntu:20.04
 
+ARG USER
+ARG USER_ID
+ARG GROUP_ID
+
 # build dependencies
 RUN apt-get update -y
 RUN apt-get install -y gcc make xorriso qemu-utils
 # grub is a bit special in containers
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install grub2 python
+
+# Create proper users so that our build artifacts
+# can be shared with the outside user
+# https://vsupalov.com/docker-shared-permissions/
+RUN addgroup --gid $GROUP_ID $USER
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID $USER
+USER $USER
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
*Description of changes:*

Adjust the way we build our docker image so that later builds run with the user and group ID of the outside user rather than root and thereby prevent file permission issues with the resulting builds.

Fixes #53 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
