### PR TITLE
Linux: detect KVM availability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,13 @@ QEMU_PARAMS += -serial stdio
 QEMU_PARAMS += -no-reboot -no-shutdown
 QEMU_PARAMS += -smp cpus=4
 ifeq ($(SYSTEM),LINUX)
+ifneq ($(USE_KVM), false) # you can hard-disable KVM use with the USE_KVM environment variable
+HAVE_KVM=$(shell lsmod | awk '/^kvm / {print $$1}')
+ifeq ($(HAVE_KVM), kvm)
 QEMU_PARAMS += -enable-kvm
-endif
+endif # HAVE_KVM
+endif # USE_KVM
+endif # SYSTEM == LINUX
 
 QEMU_PARAMS_KERNEL := -append "param1 param2 param3"
 QEMU_PARAMS_DEBUG := -s &


### PR DESCRIPTION
Allow users to explicitly disable KVM via environment variable USE_KVM. Add a
mechanism that checks if KVM is actually available before setting the
respective QEMU command line flag.

Signed-off-by: Bjoern Doebel <bjoern.doebel@gmail.com>

Fixes #54 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
