### PR TITLE
Implement a simple memmove

### DIFF
--- a/drivers/vga.c
+++ b/drivers/vga.c
@@ -52,7 +52,8 @@ void vga_write(const char *buf, size_t len, vga_color_t color) {
 
         /* Scroll up one row when hit end of VGA area */
         if (row == (MAX_ROWS - 1)) {
-            memcpy(vga_buffer[0], vga_buffer[1], sizeof(vga_buffer) - MAX_COLS);
+            memmove(vga_buffer[0], vga_buffer[1],
+                    sizeof(vga_buffer) - sizeof(vga_buffer[0]));
             memset(vga_buffer[MAX_ROWS - 1], 0x00, MAX_COLS);
             col = 0;
             row--;

--- a/include/string.h
+++ b/include/string.h
@@ -106,6 +106,38 @@ static inline void *memcpy(void *d, void *s, size_t n) {
     return d;
 }
 
+static inline void *memmove(void *d, const void *s, size_t n) {
+
+    /* dst and src are the same */
+    if (d == s) {
+        return d;
+    }
+
+    /* if we don't have a range overlap, just use memcpy */
+    if ((d > s && d > s + n) || (d < s && d + n < s)) {
+        return memcpy(d, (void *) s, n);
+    }
+
+    /*
+     * s ------
+     * d    ------
+     * needs reverse moving
+     */
+    if (s < d) {
+        while (n--)
+            *((char *) d + n) = *((char *) s + n);
+    }
+    else
+        /*
+         * s     ------
+         * d   -----
+         * normal copy
+         */
+        return memcpy(d, (void *) s, n);
+
+    return d;
+}
+
 static inline int memcmp(const void *m1, const void *m2, size_t n) {
     const uint8_t *_m1 = m1;
     const uint8_t *_m2 = m2;

--- a/tests/test.c
+++ b/tests/test.c
@@ -43,6 +43,10 @@ bool_cmd("boolean", opt_bool);
 
 static bool opt_booltwo = 0;
 bool_cmd("booleantwo", opt_booltwo);
+
+static char memmove_string[4];
+static char range_string[] = "123456";
+static char *src, *dst;
 #endif
 
 static int __user_text func(void *arg) { return 0; }
@@ -79,6 +83,26 @@ void test_main(void) {
     }
     else {
         printk("Boolean parameter parsing works!\n");
+    }
+
+    printk("\nMemmove testing:\n");
+    (void) memmove(memmove_string, opt_string, sizeof(opt_string));
+    if (!strcmp(memmove_string, opt_string)) {
+        printk("Moving around memory works!\n");
+    }
+    else {
+        printk("Memmove'ing did not work: %s (%p) != %s (%p)\n", memmove_string,
+               memmove_string, opt_string, opt_string);
+    }
+
+    src = (char *) range_string;
+    dst = (char *) range_string + 2;
+    (void) memmove(dst, src, 4);
+    if (!strcmp(range_string, "121234")) {
+        printk("Moving around memory with overlaping ranges works!\n");
+    }
+    else {
+        printk("Overlaping memmove'ing did not work: %s != %s\n", range_string, "121234");
     }
 #endif
 


### PR DESCRIPTION
*Issue #:* #62 

*Description of changes:*

This series implements a simple memmove, with checking for overlapping areas. This currently does NOT support if one of the addresses is solely in the range of the other address.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing done**
- added unittests for checking that memmove works
- booted the iso in vbox, where we have output via VGA