### PR TITLE
coverity complain: fixing report from coverity/scrutinice

### DIFF
--- a/arch/x86/traps.c
+++ b/arch/x86/traps.c
@@ -179,8 +179,8 @@ static void dump_segment_regs(const struct cpu_regs *regs) {
            "ES=0x%04lx FS=0x%04lx GS=0x%04lx\n"
            "EXCEPTION:\n"
            "CS=0x%04x SS=0x%04x\n\n",
-           read_cs(), read_ds(), read_ss(), read_es(), read_fs(), read_gs(), regs->cs,
-           regs->ss);
+           read_cs(), read_ds(), read_ss(), read_es(), read_fs(), read_gs(),
+           _ul(regs->cs), _ul(regs->ss));
 }
 
 static void dump_flags(const struct cpu_regs *regs) {


### PR DESCRIPTION
In my last commit 11d43b49ccd3eb5f2565baae21bcbeb94015fb5e,
seems like I missed cs and ss to satisfy format specifier.

Here is coverity report from last time 
https://t.corp.amazon.com/V241855618/overview

Signed-off-by: Deepak Gupta <dkgupta@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
