### PR TITLE
drivers: add basic PIC initialization

### DIFF
--- a/common/setup.c
+++ b/common/setup.c
@@ -42,6 +42,7 @@
 #include <mm/vmm.h>
 #include <smp/smp.h>
 
+#include <drivers/pic.h>
 #include <drivers/serial.h>
 #include <slab.h>
 
@@ -156,6 +157,12 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     init_console();
 
     init_boot_traps();
+
+    /* Initialize Programmable Interrupt Controller */
+    init_pic();
+
+    /* PIC is initialized - enable local interrupts */
+    sti();
 
     if (multiboot_magic == MULTIBOOT_BOOTLOADER_MAGIC) {
         /* Indentity mapping is still on, so fill in multiboot structures */

--- a/drivers/pic.c
+++ b/drivers/pic.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <drivers/pic.h>
+#include <ktf.h>
+#include <lib.h>
+
+static inline void pic_outb(io_port_t port, unsigned char value) {
+    outb(port, value);
+    io_delay();
+}
+
+void init_pic(void) {
+    /* Cascade mode initialization sequence */
+    pic_outb(PIC1_PORT_CMD, PIC_ICW1_INIT | PIC_ICW1_ICW4);
+    pic_outb(PIC2_PORT_CMD, PIC_ICW1_INIT | PIC_ICW1_ICW4);
+
+    /* Remap PICs interrupt vectors */
+    pic_outb(PIC1_PORT_DATA, PIC_IRQ0_OFFSET);
+    pic_outb(PIC2_PORT_DATA, PIC_IRQ8_OFFSET);
+
+    /* Set PIC1 and PIC2 cascade IRQ */
+    outb(PIC1_PORT_DATA, PIC_CASCADE_PIC1_IRQ);
+    outb(PIC2_PORT_DATA, PIC_CASCADE_PIC2_IRQ);
+
+    /* PIC mode: 80x86, Automatic EOI */
+    outb(PIC1_PORT_DATA, PIC_ICW4_8086 | PIC_ICW4_AUTO);
+    outb(PIC2_PORT_DATA, PIC_ICW4_8086 | PIC_ICW4_AUTO);
+
+    /* Mask the 8259A PICs by setting all IMR bits */
+    outb(PIC1_PORT_DATA, 0xFF);
+    outb(PIC2_PORT_DATA, 0xFF);
+}

--- a/include/drivers/pic.h
+++ b/include/drivers/pic.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef KTF_DRV_PIC_H
+#define KTF_DRV_PIC_H
+
+#include <ktf.h>
+
+#define PIC1_PORT_CMD  0x20
+#define PIC2_PORT_CMD  0xa0
+#define PIC1_PORT_DATA (PIC1_PORT_CMD + 1)
+#define PIC2_PORT_DATA (PIC2_PORT_CMD + 1)
+
+#define PIC_EOI 0x20 /* End-of-interrupt command code */
+
+#define PIC_ICW1_ICW4      0x01
+#define PIC_ICW1_SINGLE    0x02 /* Single (cascade) mode */
+#define PIC_ICW1_INTERVAL4 0x04 /* Call address interval 4 (8) */
+#define PIC_ICW1_LEVEL     0x08 /* Level triggered (edge) mode */
+#define PIC_ICW1_INIT      0x10
+
+#define PIC_ICW4_8086     0x01 /* 8086/88 (MCS-80/85) mode */
+#define PIC_ICW4_AUTO     0x02 /* Auto (normal) EOI */
+#define PIC_ICW4_BUF_PIC2 0x08 /* Buffered mode PIC2 */
+#define PIC_ICW4_BUF_PIC1 0x0C /* Buffered mode PIC1 */
+#define PIC_ICW4_SFNM     0x10 /* Special fully nested mode */
+
+#define PIC_CASCADE_PIC2_IRQ 0x02
+#define PIC_CASCADE_PIC1_IRQ 0x04
+
+#define PIC_IRQ0_OFFSET 0x20
+#define PIC_IRQ8_OFFSET 0x28
+
+/* External declarations */
+
+extern void init_pic(void);
+
+#endif /* KTF_DRV_PIC_H */


### PR DESCRIPTION
Initialize PIC1 and PIC2 8259A controllers to a cascade and 80x86 mode
with automatic EOI.  Remap default interrupt vectors to offset 0x20
for PIC1 and 0x28 for PIC2.  Mask all interrupt vectors by default on
both PIC1 and PIC2.

After PICs are initialized, remapped and disabled, enable local
interrupts.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
