### PR TITLE
#103 ret2kern restores flags correctly

### DIFF
--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -84,6 +84,9 @@ END_FUNC(handle_exception)
 ENTRY(usermode_call_asm)
     /* FIXME: Add 32-bit support */
 
+    /* will be restored on entering back in kernel mode */
+    PUSHF
+
     mov %_ASM_SP, %gs:(%rdx)
 
     /* SS + SP */
@@ -91,11 +94,7 @@ ENTRY(usermode_call_asm)
     push %gs:(%rcx)
 
     /* EFLAGS */
-#if defined(__x86_64__)
-    pushfq
-#else
-    pushf
-#endif
+    PUSHF
 
     orl $X86_EFLAGS_IOPL, (%_ASM_SP)
 

--- a/common/kernel.c
+++ b/common/kernel.c
@@ -36,7 +36,11 @@ extern int usermode_call_asm(user_func_t fn, void *fn_arg, unsigned long ret2ker
                              unsigned long user_stack);
 
 void ret2kern_handler(void) {
-    asm volatile("mov %%gs:(%0), %%" STR(_ASM_SP)::"r"(offsetof(percpu_t, ret2kern_sp)));
+    /* clang-format off */
+    asm volatile("mov %%gs:(%0), %%" STR(_ASM_SP) "\n"
+                 "POPF \n"
+                 ::"r"(offsetof(percpu_t, ret2kern_sp)));
+    /* clang-format on */
 }
 
 int usermode_call(user_func_t fn, void *fn_arg) {

--- a/include/arch/x86/asm-macros.h
+++ b/include/arch/x86/asm-macros.h
@@ -94,6 +94,22 @@
     pop %_ASM_AX
 .endm
 
+.macro PUSHF
+#if defined(__x86_64__)
+    pushfq
+#else
+    pushf
+#endif
+.endm
+
+.macro POPF
+#if defined(__x86_64__)
+    popfq
+#else
+    popf
+#endif
+.endm
+
 #define GLOBAL(name) \
     .global name;    \
 name:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/ktf/issues/103

*Description of changes:*
Correctly restore the flags upon returning to kernel mode


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
