### PR TITLE
pagetables: harden get_pgentry_mfn()

### DIFF
--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -120,8 +120,7 @@ static mfn_t get_pgentry_mfn(mfn_t tab_mfn, pt_index_t index, unsigned long flag
     pgentry_t *tab, *entry;
     mfn_t mfn;
 
-    if (mfn_invalid(tab_mfn))
-        return MFN_INVALID;
+    BUG_ON(mfn_invalid(tab_mfn));
 
     tab = init_map_mfn(tab_mfn);
     entry = &tab[index];
@@ -130,6 +129,8 @@ static mfn_t get_pgentry_mfn(mfn_t tab_mfn, pt_index_t index, unsigned long flag
     if (mfn_invalid(mfn)) {
         set_pgentry(entry, get_free_frame(), flags);
         mfn = mfn_from_pgentry(*entry);
+        tab = init_map_mfn(mfn);
+        memset(tab, 0, PAGE_SIZE);
     }
 
     return mfn;


### PR DESCRIPTION
Calling `get_pgentry_mfn()` with invalid table MFN is an unrecoverable
bug and must not happen, hence the BUG_ON.

Whenever a new frame is obtained for a new page table, map and zero it
out. That way we do not have garbage entries in it.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
