### PR TITLE
ACPI: fix multi-page ACPI table allocation

### DIFF
--- a/common/acpi.c
+++ b/common/acpi.c
@@ -39,6 +39,14 @@ unsigned max_acpi_tables;
 
 static unsigned nr_cpus;
 
+unsigned acpi_get_nr_cpus(void) { return nr_cpus; }
+
+/* Calculate number of entries in the ACPI table.
+ * Formula: (table_length - header_length) / entry_size
+ */
+#define ACPI_NR_TABLES(ptr)                                                              \
+    (((ptr)->header.length - sizeof((ptr)->header)) / sizeof(*((ptr)->entry)))
+
 static inline uint8_t get_checksum(void *ptr, size_t len) {
     uint8_t checksum = 0;
 
@@ -217,10 +225,6 @@ acpi_table_t *acpi_find_table(uint32_t signature) {
     return NULL;
 }
 
-unsigned acpi_get_nr_cpus(void) { return nr_cpus; }
-
-#define ACPI_NR_TABLES(ptr)                                                              \
-    (((ptr)->header.length - sizeof((ptr)->header)) / sizeof(*(ptr)->entry))
 void init_acpi(void) {
     printk("Initializing ACPI support\n");
 

--- a/common/acpi.c
+++ b/common/acpi.c
@@ -125,6 +125,14 @@ static inline void *acpi_map_table(paddr_t pa) {
     return kmap(mfn, PAGE_ORDER_4K, L1_PROT) + offset;
 }
 
+static inline void acpi_dump_table(const void *tab, const acpi_table_hdr_t *hdr) {
+    printk("ACPI: %.*s [%p] %04x (v%04x %.*s %04x %.*s %08x)\n",
+           _int(sizeof(hdr->signature)), (char *) &hdr->signature, tab, hdr->length,
+           hdr->rev, _int(sizeof(hdr->oem_id)), hdr->oem_id, hdr->oem_rev,
+           _int(sizeof(hdr->asl_compiler_id)), hdr->asl_compiler_id,
+           hdr->asl_compiler_rev);
+}
+
 static inline rsdt_t *acpi_find_rsdt(const rsdp_rev1_t *rsdp) {
     rsdt_t *rsdt = acpi_map_table(rsdp->rsdt_paddr);
 
@@ -155,17 +163,9 @@ static inline xsdt_t *acpi_find_xsdt(const rsdp_rev2_t *rsdp) {
     return xsdt;
 }
 
-static void acpi_dump_tables(void) {
-    for (unsigned int i = 0; i < max_acpi_tables; i++) {
-        acpi_table_t *tab = acpi_tables[i];
-        acpi_table_hdr_t *hdr = &tab->header;
-
-        printk("ACPI: %.*s [%p] %04x (v%04x %.*s %04x %.*s %08x)\n",
-               _int(sizeof(hdr->signature)), (char *) &hdr->signature, tab, hdr->length,
-               hdr->rev, _int(sizeof(hdr->oem_id)), hdr->oem_id, hdr->oem_rev,
-               _int(sizeof(hdr->asl_compiler_id)), hdr->asl_compiler_id,
-               hdr->asl_compiler_rev);
-    }
+static inline void acpi_dump_tables(void) {
+    for (unsigned int i = 0; i < max_acpi_tables; i++)
+        acpi_dump_table(acpi_tables[i], &acpi_tables[i]->header);
 }
 
 static unsigned process_madt_entries(void) {

--- a/include/acpi.h
+++ b/include/acpi.h
@@ -77,10 +77,7 @@ typedef struct rsdt rsdt_t;
 
 struct xsdt {
     acpi_table_hdr_t header;
-    struct {
-        uint32_t low;
-        uint32_t high;
-    } entry[0];
+    uint64_t entry[0];
 } __packed;
 typedef struct xsdt xsdt_t;
 


### PR DESCRIPTION
An ACPI table may span multiple 4K pages because of its multi-page
size or its starting offset (page crossing table).
Introduce `acpi_table_map_pages()` and `acpi_table_unmap_pages()` routines
properly detecting starting page as well as number of pages required
for a table.

It is also essential to map entire ACPI table before its checksum
validation.  For almost all tables (except XSDT) the mapping process
needs to be split into ACPI table header page mapping, where the
entire table length can be obtained, and then the entire table
mapping.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

* Issue #102 *
* Fixes #102 *

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
