### PR TITLE
uart serial input

### DIFF
--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -81,6 +81,19 @@ ENTRY(handle_exception)
 #endif
 END_FUNC(handle_exception)
 
+ENTRY(asm_uart_handler)
+    cld
+    SAVE_REGS
+    lea com_ports, %_ASM_DI
+    call uart_handler
+    RESTORE_REGS
+#if defined(__x86_64__)
+    iretq
+#else
+    iret
+#endif
+END_FUNC(asm_uart_handler)
+
 ENTRY(usermode_call_asm)
     /* FIXME: Add 32-bit support */
 

--- a/arch/x86/traps.c
+++ b/arch/x86/traps.c
@@ -24,6 +24,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include <console.h>
+#include <drivers/serial.h>
 #include <ktf.h>
 #include <lib.h>
 #include <percpu.h>
@@ -37,6 +38,7 @@
 #include <mm/vmm.h>
 
 extern void ret2kern_handler(void);
+extern void asm_uart_handler(void);
 
 static void init_tss(percpu_t *percpu) {
 #if defined(__i386__)
@@ -142,6 +144,11 @@ void init_traps(unsigned int cpu) {
     /* User mode return to kernel handler */
     set_intr_gate(&percpu->idt[X86_RET2KERN_INT], __KERN_CS, _ul(ret2kern_handler), GATE_DPL3, GATE_PRESENT, 0);
     /* clang-format on */
+
+    set_intr_gate(&percpu->idt[COM1_IRQ0_OFFSET], __KERN_CS, _ul(asm_uart_handler),
+                  GATE_DPL0, GATE_PRESENT, 0);
+    set_intr_gate(&percpu->idt[COM2_IRQ0_OFFSET], __KERN_CS, _ul(asm_uart_handler),
+                  GATE_DPL0, GATE_PRESENT, 0);
 
     barrier();
     lidt(&percpu->idt_ptr);

--- a/common/kernel.c
+++ b/common/kernel.c
@@ -68,5 +68,5 @@ void kernel_main(void) {
     printk("All tasks done.\n");
 
     while (1)
-        halt();
+        io_delay();
 }

--- a/common/setup.c
+++ b/common/setup.c
@@ -161,6 +161,9 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     /* Initialize Programmable Interrupt Controller */
     init_pic();
 
+    /* Initialize console input */
+    uart_input_init();
+
     /* PIC is initialized - enable local interrupts */
     sti();
 

--- a/drivers/pic.c
+++ b/drivers/pic.c
@@ -52,3 +52,12 @@ void init_pic(void) {
     outb(PIC1_PORT_DATA, 0xFF);
     outb(PIC2_PORT_DATA, 0xFF);
 }
+
+void pic_enable_irq(pic_device_sel_t pic, uint8_t irq) {
+    BUG_ON((pic != PIC1_DEVICE_SEL && pic != PIC2_DEVICE_SEL) ||
+           irq >= PIC_IRQ_END_OFFSET);
+    uint8_t port = (pic == PIC1_DEVICE_SEL ? PIC1_PORT_DATA : PIC2_PORT_DATA);
+    uint8_t unmasked_irqs = inb(port);
+
+    outb(port, (~(1 << irq)) & unmasked_irqs);
+}

--- a/include/drivers/pic.h
+++ b/include/drivers/pic.h
@@ -52,8 +52,14 @@
 #define PIC_IRQ0_OFFSET 0x20
 #define PIC_IRQ8_OFFSET 0x28
 
+#define PIC_IRQ_END_OFFSET 0x08 /* One beyond the max IRQ number */
+
+enum pic_device_sel { PIC1_DEVICE_SEL = 1, PIC2_DEVICE_SEL };
+typedef enum pic_device_sel pic_device_sel_t;
+
 /* External declarations */
 
 extern void init_pic(void);
+extern void pic_enable_irq(pic_device_sel_t pic, uint8_t irq);
 
 #endif /* KTF_DRV_PIC_H */

--- a/include/drivers/serial.h
+++ b/include/drivers/serial.h
@@ -25,6 +25,7 @@
 #ifndef KTF_DRV_SERIAL_H
 #define KTF_DRV_SERIAL_H
 
+#include <drivers/pic.h>
 #include <ktf.h>
 
 union line_control_register {
@@ -98,10 +99,17 @@ union interrupt_enable_register {
 };
 typedef union interrupt_enable_register ier_t;
 
+#define COM1_IRQ         4 /* IRQ 4 */
+#define COM2_IRQ         3 /* IRQ 3 */
+#define COM1_IRQ0_OFFSET (PIC_IRQ0_OFFSET + COM1_IRQ)
+#define COM2_IRQ0_OFFSET (PIC_IRQ0_OFFSET + COM2_IRQ)
+
 #define UART_TXD_REG_OFFSET 0x00
+#define UART_RBR_REG_OFFSET 0x00
 #define UART_IER_REG_OFFSET 0x01
 #define UART_DLL_REG_OFFSET 0x00
 #define UART_DLH_REG_OFFSET 0x01
+#define UART_IIR_REG_OFFSET 0x02
 #define UART_FCR_REG_OFFSET 0x02
 #define UART_LCR_REG_OFFSET 0x03
 #define UART_MCR_REG_OFFSET 0x04
@@ -111,9 +119,14 @@ typedef union interrupt_enable_register ier_t;
 
 #define DEFAULT_BAUD_SPEED 115200
 
+#define UART_IIR_STATUS_MASK 0x0E /* bits 3, 2, 1 */
+#define UART_IIR_RBR_READY   0x04
+
 /* External declarations */
 
 extern void uart_init(io_port_t port, unsigned baud);
+extern void uart_handler(io_port_t ports[2]);
+extern void uart_input_init();
 extern int serial_putchar(io_port_t port, char c);
 extern int serial_write(io_port_t port, const char *buf, size_t len);
 


### PR DESCRIPTION
*Issue #, if available:*
#100 

*Description of changes:*
I added serial console input.

PIC is enabled after enabling the console, that's why I enabled the irqs when needed (in kernel.c). I could've moved the PIC init earlier, but [this comment](https://github.com/82marbag/ktf/blob/bafdce321e111bae71c224b61e4c1f4926197fb2/common/setup.c#L157) made me think there could be a reason to keep it there.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
