### PR TITLE
Coverity fixup for overflowing string buffers

### DIFF
--- a/common/setup.c
+++ b/common/setup.c
@@ -101,7 +101,13 @@ void __text_init cmdline_parse(const char *cmdline) {
 
             switch (param->type) {
             case STRING:
-                strcpy(param->var, optval);
+                strncpy(param->var, optval, param->varlen);
+                if (strlen(optval) >= param->varlen) {
+                    ((char *) param->var)[param->varlen - 1] = '\0';
+                    printk("WARNING: The commandline parameter value for %s does not fit "
+                           "into the preallocated buffer (size %lu >= %u)\n",
+                           param->name, strlen(optval), param->varlen);
+                }
                 break;
             case ULONG:
                 *(unsigned long *) param->var = strtoul(optval, NULL, 0);

--- a/grub/boot/grub/grub-test.cfg
+++ b/grub/boot/grub/grub-test.cfg
@@ -5,6 +5,6 @@ terminal_input --append serial
 terminal_output --append serial
 
 menuentry "kernel64" {
-   multiboot /boot/kernel64.bin      integer=42   boolean=1   string=foo booleantwo
+   multiboot /boot/kernel64.bin      integer=42   boolean=1   string=foo badstring=toolong booleantwo
    boot
 }

--- a/include/cmdline.h
+++ b/include/cmdline.h
@@ -33,6 +33,7 @@ struct __packed ktf_param {
     char name[PARAM_MAX_LENGTH];
     enum { STRING, ULONG, BOOL } type;
     void *var;
+    unsigned int varlen;
 };
 
 #define __ktfparam static __cmdline __used __aligned(1) struct ktf_param
@@ -43,7 +44,7 @@ struct __packed ktf_param {
 
 #define cmd_param(_name, _var, _type)                                                    \
     __param_size_check(_var, _name);                                                     \
-    __ktfparam __cmd_##_var = {_name, _type, &_var};
+    __ktfparam __cmd_##_var = {_name, _type, &_var, sizeof(_var)};
 
 #define bool_cmd(_cmdname, _varname)   cmd_param(_cmdname, _varname, BOOL)
 #define ulong_cmd(_cmdname, _varname)  cmd_param(_cmdname, _varname, ULONG)

--- a/tests/test.c
+++ b/tests/test.c
@@ -35,6 +35,9 @@ extern char *kernel_cmdline;
 static char opt_string[4];
 string_cmd("string", opt_string);
 
+static char opt_badstring[5];
+string_cmd("badstring", opt_badstring);
+
 static unsigned long opt_ulong;
 ulong_cmd("integer", opt_ulong);
 
@@ -62,6 +65,14 @@ void test_main(void) {
 
     if (strcmp(opt_string, "foo")) {
         printk("String parameter opt_string != foo: %s\n", opt_string);
+        BUG();
+    }
+    else {
+        printk("String parameter parsing works!\n");
+    }
+
+    if (strcmp(opt_badstring, "tool")) {
+        printk("String parameter opt_badstring != tool: %s\n", opt_badstring);
         BUG();
     }
     else {


### PR DESCRIPTION
*Description of changes:*

This fixes a Coverity finding where due to using strcpy a possible buffer overflow could have happened. We are now properly storing the length of a commandline argument and using that for the copy operation later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
