### PR TITLE
acpi: use ACPI config by default

### DIFF
--- a/common/setup.c
+++ b/common/setup.c
@@ -40,6 +40,7 @@
 
 #include <mm/pmm.h>
 #include <mm/vmm.h>
+#include <smp/mptables.h>
 #include <smp/smp.h>
 
 #include <drivers/pic.h>
@@ -198,11 +199,13 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
 
     init_percpu();
 
-    init_acpi();
-
     init_traps(0);
 
     init_slab();
+
+    if (init_acpi() < 0 && init_mptables() < 0) {
+        BUG();
+    }
 
     init_apic(APIC_MODE_XAPIC);
 

--- a/include/acpi.h
+++ b/include/acpi.h
@@ -189,6 +189,6 @@ typedef struct acpi_madt acpi_madt_t;
 extern acpi_table_t *acpi_find_table(uint32_t signature);
 
 extern unsigned acpi_get_nr_cpus(void);
-extern void init_acpi(void);
+extern int init_acpi(void);
 
 #endif /* KTF_ACPI_H */

--- a/include/smp/mptables.h
+++ b/include/smp/mptables.h
@@ -122,9 +122,7 @@ typedef struct mpc_ioapic_entry mpc_ioapic_entry_t;
 struct mpc_ioint_entry {
     uint8_t type;
     uint8_t int_type;
-    struct {
-        uint16_t po : 1, el : 1, rsvd : 14;
-    };
+    uint16_t po : 2, el : 2, rsvd : 12;
     uint8_t src_bus_id;
     uint8_t src_bus_irq;
     uint8_t dst_ioapic_id;
@@ -135,9 +133,7 @@ typedef struct mpc_ioint_entry mpc_ioint_entry_t;
 struct mpc_lint_entry {
     uint8_t type;
     uint8_t int_type;
-    struct {
-        uint16_t po : 1, el : 1, rsvd : 14;
-    };
+    uint16_t po : 2, el : 2, rsvd : 12;
     uint8_t src_bus_id;
     uint8_t src_bus_irq;
     uint8_t dst_lapic_id;
@@ -147,6 +143,7 @@ typedef struct mpc_lint_entry mpc_lint_entry_t;
 
 /* External declarations */
 
-extern unsigned mptables_init(void);
+extern unsigned mptables_get_nr_cpus(void);
+extern int init_mptables(void);
 
 #endif /* KTF_MPTABLES_H */

--- a/smp/smp.c
+++ b/smp/smp.c
@@ -94,7 +94,7 @@ static __text_init void boot_cpu(unsigned int cpu) {
 }
 
 void __text_init init_smp(void) {
-    unsigned mp_nr_cpus = mptables_init();
+    unsigned mp_nr_cpus = mptables_get_nr_cpus();
     unsigned acpi_nr_cpus = acpi_get_nr_cpus();
 
     nr_cpus = acpi_nr_cpus ?: mp_nr_cpus;


### PR DESCRIPTION
User ACPI tables for system configuration by default, and only
when not available fallback to MP tables configuration.

Initialize ACPI after BSP traps and SLAB support are initialized.

Fix MP tables IOINT and LINT data structure error (polarity and
trigger_mode take 2 bits).

init_mptables() is not called from setup and no longer returns number
of detected CPUs. There is new function: mptables_get_nr_cpus() for
that purpose.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

This is part of the changes needed to implement IOAPIC feature: #88 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
