### PR TITLE
Add IOAPIC detection and basic functionality

### DIFF
--- a/arch/x86/ioapic.c
+++ b/arch/x86/ioapic.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <console.h>
+#include <ioapic.h>
+#include <ktf.h>
+#include <list.h>
+#include <slab.h>
+#include <string.h>
+
+#define IOAPIC_SYSTEM_ISA_BUS_NAME "ISA"
+#define IOAPIC_SYSTEM_PCI_BUS_NAME "PCI"
+
+/* MP specification defines bus name as array of 6 characters filled up with blanks */
+#define IOAPIC_SYSTEM_BUS_NAME_SIZE 6
+
+static list_head_t bus_list = LIST_INIT(bus_list);
+
+static int __get_system_bus_name(uint8_t bus_name[IOAPIC_SYSTEM_BUS_NAME_SIZE],
+                                 const char *name, size_t namelen) {
+    if (namelen > IOAPIC_SYSTEM_BUS_NAME_SIZE)
+        return -EINVAL;
+
+    memset(bus_name, ' ', IOAPIC_SYSTEM_BUS_NAME_SIZE);
+    memcpy(bus_name, (char *) name, namelen);
+    return 0;
+}
+
+static bus_t *get_system_bus_by_name(const char *name, size_t namelen) {
+    uint8_t bus_name[IOAPIC_SYSTEM_BUS_NAME_SIZE];
+    bus_t *bus;
+
+    if (__get_system_bus_name(bus_name, name, namelen) < 0)
+        return NULL;
+
+    list_for_each_entry (bus, &bus_list, list) {
+        if (!memcmp(bus->name, bus_name, sizeof(bus->name)))
+            return bus;
+    }
+
+    return NULL;
+}
+
+static bus_t *get_system_bus_by_id(uint8_t id) {
+    bus_t *bus;
+
+    list_for_each_entry (bus, &bus_list, list) {
+        if (bus->id == id)
+            return bus;
+    }
+
+    return NULL;
+}
+
+static bus_t *__add_system_bus(uint8_t id,
+                               uint8_t bus_name[IOAPIC_SYSTEM_BUS_NAME_SIZE]) {
+    bus_t *new_bus = ktf_alloc(sizeof(*new_bus));
+    BUG_ON(!new_bus);
+
+    new_bus->id = id;
+    memcpy(new_bus->name, bus_name, sizeof(new_bus->name));
+    list_init(&new_bus->irq_overrides);
+
+    list_add_tail(&new_bus->list, &bus_list);
+    return new_bus;
+}
+
+bus_t *add_system_bus(uint8_t id, const char *name, size_t namelen) {
+    uint8_t bus_name[IOAPIC_SYSTEM_BUS_NAME_SIZE];
+    bus_t *bus;
+
+    if (__get_system_bus_name(bus_name, name, namelen) < 0) {
+        printk("System Bus ID(%u) '%s' unsupported\n", id, name);
+        return NULL;
+    }
+
+    bus = get_system_bus_by_id(id);
+    if (bus) {
+        if (memcmp(bus->name, bus_name, sizeof(bus->name))) {
+            printk("System Bus ID(%u) name mismatch (actual: %6s, expected: %6s)\n", id,
+                   bus->name, bus_name);
+            return NULL;
+        }
+        return bus;
+    }
+
+    bus = __add_system_bus(id, bus_name);
+    return bus;
+}

--- a/common/acpi.c
+++ b/common/acpi.c
@@ -24,6 +24,7 @@
  */
 #include <acpi.h>
 #include <errno.h>
+#include <ioapic.h>
 #include <ktf.h>
 #include <lib.h>
 #include <mm/pmm.h>
@@ -223,12 +224,18 @@ static const char *madt_int_trigger_names[] = {
 static int process_madt_entries(void) {
     acpi_madt_t *madt = (acpi_madt_t *) acpi_find_table(MADT_SIGNATURE);
     acpi_madt_entry_t *entry;
+    bus_t *isa_bus;
 
     if (!madt)
         return -ENOENT;
 
     printk("ACPI: [MADT] LAPIC Addr: %p, Flags: %08x\n", _ptr(madt->lapic_addr),
            madt->flags);
+
+    isa_bus =
+        add_system_bus(ACPI_MADT_INT_BUS_ISA, madt_int_bus_names[ACPI_MADT_INT_BUS_ISA],
+                       strlen(madt_int_bus_names[ACPI_MADT_INT_BUS_ISA]));
+    BUG_ON(!isa_bus);
 
     for (void *addr = madt->entry; addr < (_ptr(madt) + madt->header.length);
          addr += entry->len) {

--- a/common/acpi.c
+++ b/common/acpi.c
@@ -202,6 +202,24 @@ static inline void acpi_dump_tables(void) {
         acpi_dump_table(acpi_tables[i], &acpi_tables[i]->header);
 }
 
+static const char *madt_int_bus_names[] = {
+    [ACPI_MADT_INT_BUS_ISA] = "ISA",
+};
+
+static const char *madt_int_polarity_names[] = {
+    [ACPI_MADT_INT_POLARITY_BS] = "Bus Spec",
+    [ACPI_MADT_INT_POLARITY_AH] = "Active High",
+    [ACPI_MADT_INT_POLARITY_RSVD] = "Reserved",
+    [ACPI_MADT_INT_POLARITY_AL] = "Active Low",
+};
+
+static const char *madt_int_trigger_names[] = {
+    [ACPI_MADT_INT_TRIGGER_BS] = "Bus Spec",
+    [ACPI_MADT_INT_TRIGGER_ET] = "Edge",
+    [ACPI_MADT_INT_TRIGGER_RSVD] = "Reserved",
+    [ACPI_MADT_INT_TRIGGER_LT] = "Level",
+};
+
 static int process_madt_entries(void) {
     acpi_madt_t *madt = (acpi_madt_t *) acpi_find_table(MADT_SIGNATURE);
     acpi_madt_entry_t *entry;
@@ -235,11 +253,59 @@ static int process_madt_entries(void) {
                    madt_cpu->apic_proc_id, madt_cpu->apic_id, madt_cpu->flags);
             break;
         }
-        case ACPI_MADT_TYPE_IOAPIC:
-        case ACPI_MADT_TYPE_IRQ_SRC:
-        case ACPI_MADT_TYPE_NMI:
-        case ACPI_MADT_TYPE_LAPIC_ADDR:
+        case ACPI_MADT_TYPE_IOAPIC: {
+            acpi_madt_ioapic_t *madt_ioapic = (acpi_madt_ioapic_t *) entry->data;
+
+            printk("ACPI: [MADT] IOAPIC ID: %u, Base Address: 0x%08x, GSI Base: 0x%08x\n",
+                   madt_ioapic->ioapic_id, madt_ioapic->base_address,
+                   madt_ioapic->gsi_base);
             break;
+        }
+        case ACPI_MADT_TYPE_IRQ_SRC: {
+            acpi_madt_irq_src_t *madt_irq_src = (acpi_madt_irq_src_t *) entry->data;
+
+            printk("ACPI: [MADT] IRQ Src Override: Bus: %3s, IRQ: 0x%02x, GSI: 0x%08x, "
+                   "Polarity: %11s, Trigger: %9s\n",
+                   madt_int_bus_names[madt_irq_src->bus], madt_irq_src->irq_src,
+                   madt_irq_src->gsi, madt_int_polarity_names[madt_irq_src->polarity],
+                   madt_int_trigger_names[madt_irq_src->trigger_mode]);
+            break;
+        }
+        case ACPI_MADT_TYPE_NMI_SRC: {
+            acpi_madt_nmi_src_t *madt_nmi_src = (acpi_madt_nmi_src_t *) entry->data;
+
+            printk("ACPI: [MADT] NMI Src: GSI: 0x%08x, Polarity: %11s, Trigger: %9s\n",
+                   madt_nmi_src->gsi, madt_int_polarity_names[madt_nmi_src->polarity],
+                   madt_int_trigger_names[madt_nmi_src->trigger_mode]);
+            break;
+        }
+        case ACPI_MADT_TYPE_LAPIC_NMI: {
+            acpi_madt_lapic_nmi_t *madt_lapic_nmi = (acpi_madt_lapic_nmi_t *) entry->data;
+
+            printk("ACPI: [MADT] Local APIC NMI LINT#: CPU UID: %02x, Polarity: %11s, "
+                   "Trigger: %9s, LINT#: 0x%02x\n",
+                   madt_lapic_nmi->cpu_uid,
+                   madt_int_polarity_names[madt_lapic_nmi->polarity],
+                   madt_int_trigger_names[madt_lapic_nmi->trigger_mode],
+                   madt_lapic_nmi->lapic_lint);
+            break;
+        }
+        case ACPI_MADT_TYPE_LAPIC_ADDR: {
+            acpi_madt_lapic_addr_t *madt_lapic_addr =
+                (acpi_madt_lapic_addr_t *) entry->data;
+
+            printk("ACPI: [MADT] Local APIC Address: 0x%016lx\n",
+                   madt_lapic_addr->lapic_addr);
+            break;
+        }
+        case ACPI_MADT_TYPE_IOSAPIC: {
+            acpi_madt_iosapic_t *madt_iosapic = (acpi_madt_iosapic_t *) entry->data;
+
+            printk("ACPI: [MADT] IOSAPIC ID: %u, Base Address: %p, GSI Base: 0x%08x\n",
+                   madt_iosapic->ioapic_id, _ptr(madt_iosapic->base_address),
+                   madt_iosapic->gsi_base);
+            break;
+        }
         default:
             panic("Unknown ACPI MADT entry type: %u\n", entry->type);
         }

--- a/common/acpi.c
+++ b/common/acpi.c
@@ -263,6 +263,9 @@ static int process_madt_entries(void) {
         case ACPI_MADT_TYPE_IOAPIC: {
             acpi_madt_ioapic_t *madt_ioapic = (acpi_madt_ioapic_t *) entry->data;
 
+            add_ioapic(madt_ioapic->ioapic_id, 0x00, true, madt_ioapic->base_address,
+                       madt_ioapic->gsi_base);
+
             printk("ACPI: [MADT] IOAPIC ID: %u, Base Address: 0x%08x, GSI Base: 0x%08x\n",
                    madt_ioapic->ioapic_id, madt_ioapic->base_address,
                    madt_ioapic->gsi_base);
@@ -336,6 +339,9 @@ static int process_madt_entries(void) {
         }
         case ACPI_MADT_TYPE_IOSAPIC: {
             acpi_madt_iosapic_t *madt_iosapic = (acpi_madt_iosapic_t *) entry->data;
+
+            add_ioapic(madt_iosapic->ioapic_id, 0x00, true, madt_iosapic->base_address,
+                       madt_iosapic->gsi_base);
 
             printk("ACPI: [MADT] IOSAPIC ID: %u, Base Address: %p, GSI Base: 0x%08x\n",
                    madt_iosapic->ioapic_id, _ptr(madt_iosapic->base_address),

--- a/common/setup.c
+++ b/common/setup.c
@@ -175,9 +175,6 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     /* Initialize Programmable Interrupt Controller */
     init_pic();
 
-    /* Initialize console input */
-    uart_input_init();
-
     /* PIC is initialized - enable local interrupts */
     sti();
 
@@ -221,6 +218,9 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     init_smp();
 
     init_ioapic();
+
+    /* Initialize console input */
+    uart_input_init(0);
 
     /* Jump from .text.init section to .text */
     asm volatile("push %0; ret" ::"r"(&kernel_main));

--- a/common/setup.c
+++ b/common/setup.c
@@ -27,6 +27,7 @@
 #include <cmdline.h>
 #include <console.h>
 #include <cpuid.h>
+#include <ioapic.h>
 #include <ktf.h>
 #include <lib.h>
 #include <multiboot.h>
@@ -218,6 +219,8 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     init_tasks();
 
     init_smp();
+
+    init_ioapic();
 
     /* Jump from .text.init section to .text */
     asm volatile("push %0; ret" ::"r"(&kernel_main));

--- a/include/acpi.h
+++ b/include/acpi.h
@@ -164,8 +164,10 @@ enum acpi_madt_type {
     ACPI_MADT_TYPE_LAPIC = 0,
     ACPI_MADT_TYPE_IOAPIC = 1,
     ACPI_MADT_TYPE_IRQ_SRC = 2,
-    ACPI_MADT_TYPE_NMI = 4,
+    ACPI_MADT_TYPE_NMI_SRC = 3,
+    ACPI_MADT_TYPE_LAPIC_NMI = 4,
     ACPI_MADT_TYPE_LAPIC_ADDR = 5,
+    ACPI_MADT_TYPE_IOSAPIC = 6,
 };
 typedef enum acpi_madt_type acpi_madt_type_t;
 
@@ -175,6 +177,66 @@ struct acpi_madt_processor {
     uint32_t flags;
 } __packed;
 typedef struct acpi_madt_processor acpi_madt_processor_t;
+
+struct acpi_madt_ioapic {
+    uint8_t ioapic_id;
+    uint8_t rsvd;
+    uint32_t base_address;
+    uint32_t gsi_base;
+} __packed;
+typedef struct acpi_madt_ioapic acpi_madt_ioapic_t;
+
+struct acpi_madt_iosapic {
+    uint8_t ioapic_id;
+    uint8_t rsvd;
+    uint32_t gsi_base;
+    uint64_t base_address;
+} __packed;
+typedef struct acpi_madt_iosapic acpi_madt_iosapic_t;
+
+#define ACPI_MADT_INT_BUS_ISA 0x00
+
+#define ACPI_MADT_IRQ_TYPE_INT 0
+#define ACPI_MADT_IRQ_TYPE_NMI 1
+
+#define ACPI_MADT_IRQ_DST_UNKNOWN 0xFF
+
+#define ACPI_MADT_INT_POLARITY_BS   0x00
+#define ACPI_MADT_INT_POLARITY_AH   0x01
+#define ACPI_MADT_INT_POLARITY_RSVD 0x02
+#define ACPI_MADT_INT_POLARITY_AL   0x03
+
+#define ACPI_MADT_INT_TRIGGER_BS   0x00
+#define ACPI_MADT_INT_TRIGGER_ET   0x01
+#define ACPI_MADT_INT_TRIGGER_RSVD 0x02
+#define ACPI_MADT_INT_TRIGGER_LT   0x03
+
+struct acpi_madt_irq_src {
+    uint8_t bus; /* Constant 0x0, ISA */
+    uint8_t irq_src;
+    uint32_t gsi;
+    uint16_t polarity : 2, trigger_mode : 2, rsvd : 12;
+} __packed;
+typedef struct acpi_madt_irq_src acpi_madt_irq_src_t;
+
+struct acpi_madt_nmi_src {
+    uint16_t polarity : 2, trigger_mode : 2, rsvd : 12;
+    uint32_t gsi;
+} __packed;
+typedef struct acpi_madt_nmi_src acpi_madt_nmi_src_t;
+
+struct acpi_madt_lapic_nmi {
+    uint8_t cpu_uid;
+    uint16_t polarity : 2, trigger_mode : 2, rsvd : 12;
+    uint8_t lapic_lint;
+} __packed;
+typedef struct acpi_madt_lapic_nmi acpi_madt_lapic_nmi_t;
+
+struct acpi_madt_lapic_addr {
+    uint16_t rsvd;
+    uint64_t lapic_addr;
+} __packed;
+typedef struct acpi_madt_lapic_addr acpi_madt_lapic_addr_t;
 
 struct acpi_madt {
     acpi_table_hdr_t header;

--- a/include/acpi.h
+++ b/include/acpi.h
@@ -199,8 +199,6 @@ typedef struct acpi_madt_iosapic acpi_madt_iosapic_t;
 #define ACPI_MADT_IRQ_TYPE_INT 0
 #define ACPI_MADT_IRQ_TYPE_NMI 1
 
-#define ACPI_MADT_IRQ_DST_UNKNOWN 0xFF
-
 #define ACPI_MADT_INT_POLARITY_BS   0x00
 #define ACPI_MADT_INT_POLARITY_AH   0x01
 #define ACPI_MADT_INT_POLARITY_RSVD 0x02

--- a/include/arch/x86/apic.h
+++ b/include/arch/x86/apic.h
@@ -39,6 +39,7 @@
 /* Local APIC definitions */
 #define APIC_ID                0x020
 #define APIC_LVR               0x030
+#define APIC_EOI               0x0b0
 #define APIC_SPIV              0x0f0
 #define APIC_SPIV_APIC_ENABLED 0x00100
 
@@ -58,6 +59,8 @@
 #define SET_APIC_DEST_FIELD(x) ((x) << 24)
 
 #define GET_SIPI_VECTOR(addr) ((_ul((addr)) >> PAGE_SHIFT) & 0xFF)
+
+#define APIC_EOI_SIGNAL 0x0
 
 #ifndef __ASSEMBLY__
 
@@ -128,6 +131,8 @@ static inline void apic_wait_ready(void) {
     while (apic_read(APIC_ICR) & APIC_ICR_BUSY)
         cpu_relax();
 }
+
+static inline void apic_EOI(void) { apic_write(APIC_EOI, APIC_EOI_SIGNAL); }
 
 #endif /* __ASSEMBLY__ */
 

--- a/include/arch/x86/ioapic.h
+++ b/include/arch/x86/ioapic.h
@@ -29,7 +29,36 @@
 #include <lib.h>
 #include <list.h>
 
+#define IOAPIC_DEST_ID_UNKNOWN ((uint8_t) 0xFF)
+
 #ifndef __ASSEMBLY__
+
+enum irq_override_polarity {
+    IOAPIC_IRQ_OVR_POLARITY_BS = 0x00,
+    IOAPIC_IRQ_OVR_POLARITY_AH = 0x01,
+    IOAPIC_IRQ_OVR_POLARITY_RSVD = 0x02,
+    IOAPIC_IRQ_OVR_POLARITY_AL = 0x03,
+};
+typedef enum irq_override_polarity irq_override_polarity_t;
+
+enum irq_override_trigger_mode {
+    IOAPIC_IRQ_OVR_TRIGGER_BS = 0x00,
+    IOAPIC_IRQ_OVR_TRIGGER_ET = 0x01,
+    IOAPIC_IRQ_OVR_TRIGGER_RSVD = 0x02,
+    IOAPIC_IRQ_OVR_TRIGGER_LT = 0x03,
+};
+typedef enum irq_override_trigger_mode irq_override_trigger_mode_t;
+
+struct irq_override {
+    list_head_t list;
+    uint8_t type;
+    uint32_t src;
+    uint32_t dst;
+    uint8_t dst_id; /* IOAPIC or LAPIC */
+    irq_override_polarity_t polarity;
+    irq_override_trigger_mode_t trigger_mode;
+};
+typedef struct irq_override irq_override_t;
 
 struct bus {
     list_head_t list;
@@ -39,9 +68,60 @@ struct bus {
 };
 typedef struct bus bus_t;
 
+enum ioapic_irq_type {
+    IOAPIC_IRQ_TYPE_INT = 0x00,
+    IOAPIC_IRQ_TYPE_NMI = 0x01,
+    IOAPIC_IRQ_TYPE_SMI = 0x10,
+    IOAPIC_IRQ_TYPE_EXTINT = 0x11,
+};
+typedef enum ioapic_irq_type ioapic_irq_type_t;
+
+enum ioapic_delivery_mode {
+    IOAPIC_DELIVERY_MODE_FIXED = 0x00,
+    IOAPIC_DELIVERY_MODE_LOWPRIO = 0x01,
+    IOAPIC_DELIVERY_MODE_SMI = 0x02,
+    IOAPIC_DELIVERY_MODE_NMI = 0x04,
+    IOAPIC_DELIVERY_MODE_INIT = 0x05,
+    IOAPIC_DELIVERY_MODE_EXTINT = 0x07,
+};
+typedef enum ioapic_deliver_mode ioapic_delivery_mode_t;
+
+enum ioapic_dest_mode {
+    IOAPIC_DEST_MODE_PHYSICAL = 0x00,
+    IOAPIC_DEST_MODE_LOGICAL = 0x01,
+};
+typedef enum ioapic_dest_mode ioapic_dest_mode_t;
+
+enum ioapic_delivery_status {
+    IOAPIC_DELIVERY_STATUS_IDLE = 0x00,
+    IOAPIC_DELIVERY_STATUS_PENDING = 0x01,
+};
+typedef enum ioapic_delivery_status ioapic_delivery_status_t;
+
+enum ioapic_trigger_mode {
+    IOAPIC_TRIGGER_MODE_EDGE = 0x00,
+    IOAPIC_TRIGGER_MODE_LEVEL = 0x01,
+};
+typedef enum ioapic_trigger_mode ioapic_trigger_mode_t;
+
+enum ioapic_polarity {
+    IOAPIC_POLARITY_AH = 0x00,
+    IOAPIC_POLARITY_AL = 0x01,
+};
+typedef enum ioapic_polarity ioapic_polarity_t;
+
+enum ioapic_int_mask {
+    IOAPIC_INT_UNMASK = 0x00,
+    IOAPIC_INT_MASK = 0x01,
+};
+typedef enum ioapic_int_mask ioapic_int_mask_t;
+
 /* External declarations */
 
 extern bus_t *add_system_bus(uint8_t id, const char *name, size_t namelen);
+extern int add_system_bus_irq_override(uint8_t bus_id, irq_override_t *irq_override);
+extern irq_override_t *get_system_isa_bus_irq(uint8_t irq_type, uint32_t irq_src);
+extern irq_override_t *get_system_pci_bus_irq(uint8_t irq_type, uint32_t irq_src);
 
 #endif /* __ASSEMBLY__ */
 

--- a/include/arch/x86/ioapic.h
+++ b/include/arch/x86/ioapic.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef KTF_IOAPIC_H
+#define KTF_IOAPIC_H
+
+#include <ktf.h>
+#include <lib.h>
+#include <list.h>
+
+#ifndef __ASSEMBLY__
+
+struct bus {
+    list_head_t list;
+    uint8_t id;
+    char name[6];
+    list_head_t irq_overrides;
+};
+typedef struct bus bus_t;
+
+/* External declarations */
+
+extern bus_t *add_system_bus(uint8_t id, const char *name, size_t namelen);
+
+#endif /* __ASSEMBLY__ */
+
+#endif /* KTF_IOAPIC_H */

--- a/include/drivers/serial.h
+++ b/include/drivers/serial.h
@@ -126,7 +126,7 @@ typedef union interrupt_enable_register ier_t;
 
 extern void uart_init(io_port_t port, unsigned baud);
 extern void uart_handler(io_port_t ports[2]);
-extern void uart_input_init();
+extern void uart_input_init(uint8_t dst_cpus);
 extern int serial_putchar(io_port_t port, char c);
 extern int serial_write(io_port_t port, const char *buf, size_t len);
 

--- a/include/list.h
+++ b/include/list.h
@@ -34,6 +34,9 @@ struct list_head {
 };
 typedef struct list_head list_head_t;
 
+#define LIST_INIT(head)                                                                  \
+    { .next = &(head), .prev = &(head) }
+
 /* Static declarations */
 
 static inline void list_init(list_head_t *head) {

--- a/smp/mptables.c
+++ b/smp/mptables.c
@@ -233,6 +233,9 @@ static void process_mpc_entries(mpc_hdr_t *mpc_ptr) {
         case MPC_IOAPIC_ENTRY: {
             mpc_ioapic_entry_t *mpc_ioapic = (mpc_ioapic_entry_t *) entry_ptr;
 
+            add_ioapic(mpc_ioapic->id, mpc_ioapic->version, mpc_ioapic->en,
+                       mpc_ioapic->base_addr, 0x0U);
+
             dump_mpc_ioapic_entry(mpc_ioapic);
             entry_ptr += sizeof(*mpc_ioapic);
             break;

--- a/smp/mptables.c
+++ b/smp/mptables.c
@@ -24,6 +24,7 @@
  */
 #include <console.h>
 #include <errno.h>
+#include <ioapic.h>
 #include <ktf.h>
 #include <lib.h>
 #include <multiboot.h>
@@ -221,6 +222,9 @@ static void process_mpc_entries(mpc_hdr_t *mpc_ptr) {
         }
         case MPC_BUS_ENTRY: {
             mpc_bus_entry_t *mpc_bus = (mpc_bus_entry_t *) entry_ptr;
+
+            add_system_bus(mpc_bus->id, (const char *) mpc_bus->type_str,
+                           sizeof(mpc_bus->type_str));
 
             dump_mpc_bus_entry(mpc_bus);
             entry_ptr += sizeof(*mpc_bus);

--- a/smp/mptables.c
+++ b/smp/mptables.c
@@ -239,6 +239,16 @@ static void process_mpc_entries(mpc_hdr_t *mpc_ptr) {
         }
         case MPC_IO_INT_ENTRY: {
             mpc_ioint_entry_t *mpc_ioint = (mpc_ioint_entry_t *) entry_ptr;
+            irq_override_t override;
+
+            memset(&override, 0, sizeof(override));
+            override.type = mpc_ioint->int_type;
+            override.src = mpc_ioint->src_bus_irq;
+            override.dst_id = mpc_ioint->dst_ioapic_id;
+            override.dst = mpc_ioint->dst_ioapic_intin;
+            override.polarity = mpc_ioint->po;
+            override.trigger_mode = mpc_ioint->el;
+            add_system_bus_irq_override(mpc_ioint->src_bus_id, &override);
 
             dump_mpc_ioint_entry(mpc_ioint);
             entry_ptr += sizeof(*mpc_ioint);
@@ -246,6 +256,16 @@ static void process_mpc_entries(mpc_hdr_t *mpc_ptr) {
         }
         case MPC_LOCAL_INT_ENTRY: {
             mpc_lint_entry_t *mpc_lint = (mpc_lint_entry_t *) entry_ptr;
+            irq_override_t override;
+
+            memset(&override, 0, sizeof(override));
+            override.type = mpc_lint->int_type;
+            override.src = mpc_lint->src_bus_irq;
+            override.dst_id = mpc_lint->dst_lapic_id;
+            override.dst = mpc_lint->dst_lapic_lintin;
+            override.polarity = mpc_lint->po;
+            override.trigger_mode = mpc_lint->el;
+            add_system_bus_irq_override(mpc_lint->src_bus_id, &override);
 
             dump_mpc_lint_entry(mpc_lint);
             entry_ptr += sizeof(*mpc_lint);


### PR DESCRIPTION
*Issue #88 *
Closes #88 

*Description of changes:*

uart: use IOAPIC's IRQ delivery for UART
apic: add APIC EOI interface
ioapic: add IOAPIC device detection and handling

    Detect all system's IOAPIC devices as advertised by ACPI (MADT) and MP
    tables. Up to 16 IOAPIC devices is supported (per ID addressing
    range).

    Add interface to access MMIO registers of IOAPIC, configure
    redirection table entries, mask/unmask IRQs and configure delivery
    mode for ISA IRQs.

ioapic: add irq overrides detection and handling

    Detect ACPI and MP tables provided IRQ and NMI overrides for IOAPIC
    and LAPIC.  Store them on their bus's overrides list.  Add interface
    functions to obtain ISA and PCI bus IRQ overrides.

ioapic: add system bus detection and handling

    This is needed to store per-bus IRQ overrides later.
    ACPI only provides overrides for ISA bus, but MP tables support
    wider range of bus types (legacy).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
