### PR TITLE
Detect CPUID vendor string

### DIFF
--- a/common/setup.c
+++ b/common/setup.c
@@ -26,6 +26,7 @@
 #include <apic.h>
 #include <cmdline.h>
 #include <console.h>
+#include <cpuid.h>
 #include <ktf.h>
 #include <lib.h>
 #include <multiboot.h>
@@ -52,6 +53,7 @@ bool_cmd("debug", opt_debug);
 io_port_t com_ports[2];
 
 const char *kernel_cmdline;
+char cpu_identifier[49];
 
 static __text_init int parse_bool(const char *s) {
     if (!strcmp("no", s) || !strcmp("off", s) || !strcmp("false", s) ||
@@ -163,6 +165,10 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     init_console();
 
     init_boot_traps();
+
+    /* Print cpu vendor info */
+    if (cpu_vendor_string(&cpu_identifier[0]))
+        printk("CPU: %.48s\n", cpu_identifier);
 
     /* Initialize Programmable Interrupt Controller */
     init_pic();

--- a/include/cpuid.h
+++ b/include/cpuid.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef KTF_CPUID_H
+#define KTF_CPUID_H
+
+#include <string.h>
+
+/* CPU vendor detection */
+#define CPUID_EXT_INFO_LEAF  0x80000000U
+#define CPUID_BRAND_INFO_MIN 0x80000002U
+#define CPUID_BRAND_INFO_MAX 0x80000004U
+
+static inline bool cpu_vendor_string(char *cpu_str) {
+    uint32_t leaf = CPUID_EXT_INFO_LEAF;
+    uint32_t ebx = 0, ecx = 0, edx = 0;
+    uint32_t eax = cpuid_eax(leaf);
+
+    if (!(eax & leaf) || (eax < CPUID_BRAND_INFO_MAX)) {
+        dprintk("Extended Function CPUID Information not supported\n");
+        return false;
+    }
+
+    for (leaf = CPUID_BRAND_INFO_MIN; leaf <= CPUID_BRAND_INFO_MAX;
+         leaf++, cpu_str += 16) {
+        cpuid(leaf, &eax, &ebx, &ecx, &edx);
+        memcpy(cpu_str, &eax, sizeof(eax));
+        memcpy(cpu_str + 4, &ebx, sizeof(ebx));
+        memcpy(cpu_str + 8, &ecx, sizeof(ecx));
+        memcpy(cpu_str + 12, &edx, sizeof(edx));
+    }
+
+    return true;
+}
+
+#endif /* KTF_CPUID_H */

--- a/include/lib.h
+++ b/include/lib.h
@@ -108,28 +108,28 @@ static inline void cpuid(uint32_t leaf, uint32_t *eax, uint32_t *ebx, uint32_t *
 }
 
 static inline uint32_t cpuid_eax(uint32_t leaf) {
-    uint32_t eax = 0, ign;
+    uint32_t eax = 0, ign = 0;
 
     cpuid(leaf, &eax, &ign, &ign, &ign);
     return eax;
 }
 
 static inline uint32_t cpuid_ebx(uint32_t leaf) {
-    uint32_t ebx = 0, ign;
+    uint32_t ebx = 0, ign = 0;
 
     cpuid(leaf, &ign, &ebx, &ign, &ign);
     return ebx;
 }
 
 static inline uint32_t cpuid_ecx(uint32_t leaf) {
-    uint32_t ecx = 0, ign;
+    uint32_t ecx = 0, ign = 0;
 
     cpuid(leaf, &ign, &ign, &ecx, &ign);
     return ecx;
 }
 
 static inline uint32_t cpuid_edx(uint32_t leaf) {
-    uint32_t edx = 0, ign;
+    uint32_t edx = 0, ign = 0;
 
     cpuid(leaf, &ign, &ign, &ign, &edx);
     return edx;

--- a/include/setup.h
+++ b/include/setup.h
@@ -35,6 +35,7 @@
 extern io_port_t com_ports[2];
 
 extern const char *kernel_cmdline;
+extern char cpu_identifier[49];
 
 static inline void get_com_ports(void) {
     memcpy((void *) com_ports, (void *) (BDA_COM_PORTS_ENTRY), sizeof(com_ports));


### PR DESCRIPTION
*Issue #, if available:* #80 

*Description of changes:*

- fix compile time warnings in lib.h
- add CPUID vendor string detection and parsing
- print CPU vendor string during bootup


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
