### PR TITLE
workflows: add one-line-cr-bot

### DIFF
--- a/.github/workflows/one-line-cr-bot.yml
+++ b/.github/workflows/one-line-cr-bot.yml
@@ -1,0 +1,80 @@
+# Author: Norbert Manthey <nmanthey@amazon.de>
+#
+# This workflow will present introduced defects of a pull request to a given
+# branch of a package.
+#
+# The workflow has locations labeled '[ACTION REQUIRED]' where adaptation for
+# your build might be required, as well as where to compare the findings to.
+#
+# To learn more about the available options, check the CLI parameters of the
+# script 'one-line-cr-bot.sh' in https://github.com/awslabs/one-line-scan.git
+name: One Line CR Bot
+
+on:
+  pull_request:
+    # [ACTION REQUIRED] Set the branch you want to analyze PRs for
+    branches: [ mainline ]
+
+  # [ACTION REQUIRED] Use this, if you want analysis for push to repository as well
+  push:
+    branches: [ mainline ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    # Get the code, fetch the full history to make sure we have the compare commit as well
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    # one-line-cr-bot.sh will get infer and cppcheck, if not available
+    - name: Install CppCheck Package
+      env:
+        # This is needed in addition to -yq to prevent apt-get from asking for user input
+        DEBIAN_FRONTEND: noninteractive
+      # [ACTION REQUIRED] Add your build dependencies here, drop cppcheck to get latest cppcheck
+      run: |
+        sudo apt-get install -y cppcheck
+
+    # Get the compare remote
+    - name: Setup Compare Remote
+      # [ACTION REQUIRED] Add the https URL of your repository
+      run: git remote add compare https://github.com/awslabs/ktf.git
+    - name: Fetch Compare Remote
+      run: git fetch compare
+
+    # Get one-line-scan, the tool we will use for analysis
+    - name: Get OneLineScan
+      run:  git clone -b one-line-cr-bot https://github.com/nmanthey/one-line-scan.git ../one-line-scan
+
+    # Check how repository is setup
+    - name: Be Verbose about Git Setup
+      run: |
+        git remote -v
+        git branch -a
+        git log --pretty=oneline --decorate --graph | head -n 10
+
+    # Run the analysis, parameterized for this package
+    - name: one-line-cr-analysis
+      env:
+        # [ACTION REQUIRED] Adapt the values below accordingly
+        # 'compare' is the name of the remote to use
+        BASE_COMMIT: "compare/mainline"
+        BUILD_COMMAND: "make -B all"
+        CLEAN_COMMAND: "make clean"
+        # Parameters to be forwarded to used tools in one-line-scan for customization
+        # Additional CppCheck parameters, do not use e.g. --inconclusive
+        CPPCHECK_EXTRA_ARG: "--enable=style --enable=performance --enable=information --enable=portability"
+        # Additional Infer parameters, do not use e.g. --pulse
+        INFER_ANALYSIS_EXTRA_ARGS: "--bufferoverrun"
+        # These settings are more preferences, and not directly related to your project
+        # Set INSTALL_MISSING to false, if ALL targetted tools are already present
+        INSTALL_MISSING: true
+        OVERRIDE_ANALYSIS_ERROR: true
+        REPORT_NEW_ONLY: true
+        VERBOSE: 0 # >0 shows all currently present defects as well
+      # Be explicit about the tools to be used
+      run: ../one-line-scan/one-line-cr-bot.sh -E infer -E cppcheck


### PR DESCRIPTION
We want fully automated code analysis. This tool and template make this
analysis possible with cppcheck and infer.

New defects will be raised, and the step will fail if there are new
defects.

Please note, this is currently an PoC, and might fail once in a while.
Furthermore, the tools can produce false positives, so that this checker
might want to be ignored once in a while.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

*Issue #, if available:* #63   

*Description of changes:*

This script adds automation to detect bugs in pull requests with the tools Infer and CppCheck. The code below in my personal branch of one-line-scan might change, and we can also customize the parameters we pass to Infer and CppCheck further, as well as adjust filtering. However, this is a first attempt to collect data and get experience with the current parameter setup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
