### PR TITLE
Add CPU frequency detection from CPUID vendor string

### DIFF
--- a/common/setup.c
+++ b/common/setup.c
@@ -170,8 +170,12 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     init_boot_traps();
 
     /* Print cpu vendor info */
-    if (cpu_vendor_string(&cpu_identifier[0]))
+    if (cpu_vendor_string(cpu_identifier)) {
         printk("CPU: %.48s\n", cpu_identifier);
+        unsigned long freq = get_cpu_freq(cpu_identifier);
+        if (freq > 0)
+            printk("Frequency: %lu MHz\n", freq / MHZ(1));
+    }
 
     /* Initialize Programmable Interrupt Controller */
     init_pic();

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -44,6 +44,10 @@
 #define MB(x) (_U64(x) << 20)
 #define GB(x) (_U64(x) << 30)
 
+#define KHZ(x) (_U64(x) * 1000)
+#define MHZ(x) (KHZ(x) * 1000)
+#define GHZ(x) (MHZ(x) * 1000)
+
 #ifndef __ASSEMBLY__
 #define _ptr(val) ((void *) (unsigned long) (val))
 #define _ul(val)  ((unsigned long) (val))

--- a/include/lib.h
+++ b/include/lib.h
@@ -381,6 +381,20 @@ static inline unsigned int next_power_of_two(unsigned int n) {
     return n;
 }
 
+static inline unsigned long ipow(int base, unsigned int exp) {
+    unsigned long result = 1;
+    for (;;) {
+        if (exp & 1)
+            result *= base;
+        exp >>= 1;
+        if (!exp)
+            break;
+        base *= base;
+    }
+
+    return result;
+}
+
 /* External declarations */
 
 extern void halt(void);

--- a/include/string.h
+++ b/include/string.h
@@ -31,6 +31,8 @@ static inline __used int isspace(int c) { return c == ' ' || c == '\t'; }
 
 static inline __used int iseostr(int c) { return c == '\0'; }
 
+static inline __used int ispunct(int c) { return c == '.'; }
+
 static inline __used int isdigit(int c) { return c >= '0' && c <= '9'; }
 
 static inline __used int isxdigit(int c) {

--- a/tests/test.c
+++ b/tests/test.c
@@ -28,6 +28,7 @@
 
 #ifdef KTF_UNIT_TEST
 #include <cmdline.h>
+#include <cpuid.h>
 #include <string.h>
 
 extern char *kernel_cmdline;
@@ -50,6 +51,18 @@ bool_cmd("booleantwo", opt_booltwo);
 static char memmove_string[4];
 static char range_string[] = "123456";
 static char *src, *dst;
+
+static void cpu_freq_expect(const char *cpu_str, uint64_t expectation) {
+    uint64_t result = get_cpu_freq(cpu_str);
+    if (result != expectation) {
+        printk("Could not parse cpu frequency from string '%s'\n", cpu_str);
+        printk("Expectation vs. result: %llu vs. %llu\n", expectation, result);
+        BUG();
+    }
+
+    printk("Got CPU string '%s' and frequency '%llu'\n", cpu_str, result);
+    return;
+}
 #endif
 
 static int __user_text func(void *arg) { return 0; }
@@ -115,6 +128,17 @@ void test_main(void) {
     else {
         printk("Overlaping memmove'ing did not work: %s != %s\n", range_string, "121234");
     }
+
+    cpu_freq_expect("Intel(R) Xeon(R) CPU E3-1270 V2 @ 3.50GHz", 3500000000);
+    cpu_freq_expect("Intel(R) Celeron(R) CPU J1900 @ 1.99GHz", 1990000000);
+    cpu_freq_expect("AMD G-T48L Processor", 0);
+    cpu_freq_expect("Intel(R) Atom(TM) CPU E3815 @ 1.46GHz", 1460000000);
+    cpu_freq_expect("Intel(R) Atom(TM) CPU E620 @ 600MHz", 600000000);
+    cpu_freq_expect("VIA C7 Processor 1000MHz", 1000000000);
+    cpu_freq_expect("Intel(R) Core(TM) i7 CPU 950 @ 3.07GHz", 3070000000);
+    cpu_freq_expect("AMD Ryzen Threadripper 1950X 16-Core Processor", 0);
+    cpu_freq_expect("Prototyp Amazing Foo One @ 1GHz", 1000000000);
+    cpu_freq_expect("Prototyp Amazing Foo Two @ 1.00GHz", 1000000000);
 #endif
 
     wait_for_all_tasks();


### PR DESCRIPTION
*Issue #, if available:* #80 

*Description of changes:*

This commit series is adding a cpu frequency detection by parsing the specific bits out of the CPUID vendor string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Testing done:
- running `UNITTEST=1 make clean boot` on the branch results in executing unit tests

```
Got CPU string 'Intel(R) Xeon(R) CPU E3-1270 V2 @ 3.50GHz' and frequency '3500000000'
Got CPU string 'Intel(R) Celeron(R) CPU J1900 @ 1.99GHz' and frequency '1990000000'
Got CPU string 'AMD G-T48L Processor' and frequency '0'
Got CPU string 'Intel(R) Atom(TM) CPU E3815 @ 1.46GHz' and frequency '1460000000'
Got CPU string 'Intel(R) Atom(TM) CPU E620 @ 600MHz' and frequency '600000000'
Got CPU string 'VIA C7 Processor 1000MHz' and frequency '1000000000'
Got CPU string 'Intel(R) Core(TM) i7 CPU 950 @ 3.07GHz' and frequency '3070000000'
Got CPU string 'AMD Ryzen Threadripper 1950X 16-Core Processor' and frequency '0'
Got CPU string 'Prototyp Amazing Foo One @ 1GHz' and frequency '1000000000'
Got CPU string 'Prototyp Amazing Foo Two @ 1.00GHz' and frequency '1000000000'
```