### PR TITLE
static-analysis: make BUG an infinite-loop

### DIFF
--- a/include/lib.h
+++ b/include/lib.h
@@ -303,7 +303,7 @@ static inline void ud2(void) { asm volatile("ud2"); }
 #define BUG()                                                                            \
     do {                                                                                 \
         ud2();                                                                           \
-    } while (0)
+    } while (true)
 #define BUG_ON(cond)                                                                     \
     do {                                                                                 \
         if ((cond))                                                                      \


### PR DESCRIPTION
Static code analysis tools likely do not understand that the ud2 inline
assembly instruction means that the control flow is terminated.
Consequently, we need to add an artificial infinite loop to make sure we
cannot continue when hitting a bug.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

*Issue #, if available:* #63 This code improves the precision of static code analysis tools.

*Description of changes:* While we might be able to annotate code, first try to make the code more clear for tools in the first place.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
