### PR TITLE
drivers: PIT delivered with APIC

### DIFF
--- a/common/setup.c
+++ b/common/setup.c
@@ -228,7 +228,7 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     uart_input_init(0);
 
     /* Initialize Programmable Interrupt Timer */
-    init_pit();
+    init_pit(0);
 
     /* Jump from .text.init section to .text */
     asm volatile("push %0; ret" ::"r"(&kernel_main));

--- a/include/drivers/pit.h
+++ b/include/drivers/pit.h
@@ -56,7 +56,7 @@ typedef enum pit_operational_mode pit_operational_mode_t;
 
 #define PIT_BCD_MODE (~(1 << 0))
 
-extern void init_pit(void);
+extern void init_pit(uint8_t dst_cpus);
 extern void pit_interrupt_handler(void);
 extern void pit_sleep(uint64_t ms);
 


### PR DESCRIPTION
PIT interrupt routed to cpus using IOAPIC IRQ delivery

Signed-off-by: Daniele Ahmed <ahmeddan amazon c;om>

*Issue #, if available:*

*Description of changes:* Routing the timer interrupt with APIC rather than PIC.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
