### PR TITLE
setup: track BSP CPU ID via common interface

### DIFF
--- a/common/percpu.c
+++ b/common/percpu.c
@@ -42,7 +42,7 @@ percpu_t *get_percpu_page(unsigned int cpu) {
     percpu_t *percpu;
 
     list_for_each_entry (percpu, &percpu_frames, list) {
-        if (percpu->id == cpu)
+        if (percpu->cpu_id == cpu)
             return percpu;
     }
 
@@ -52,7 +52,7 @@ percpu_t *get_percpu_page(unsigned int cpu) {
     percpu = get_free_page(GFP_IDENT | GFP_KERNEL);
     BUG_ON(!percpu);
 
-    percpu->id = cpu;
+    percpu->cpu_id = cpu;
     percpu->user_stack = get_free_page_top(GFP_USER);
 
     list_add(&percpu->list, &percpu_frames);

--- a/include/acpi.h
+++ b/include/acpi.h
@@ -249,6 +249,6 @@ typedef struct acpi_madt acpi_madt_t;
 extern acpi_table_t *acpi_find_table(uint32_t signature);
 
 extern unsigned acpi_get_nr_cpus(void);
-extern int init_acpi(void);
+extern int init_acpi(unsigned bsp_cpu_id);
 
 #endif /* KTF_ACPI_H */

--- a/include/percpu.h
+++ b/include/percpu.h
@@ -32,8 +32,14 @@
 
 struct percpu {
     list_head_t list;
-    unsigned int id : 8, apic_id : 8, enabled : 1, bsp : 1, family : 4, model : 4,
-        stepping : 4;
+
+    unsigned int cpu_id;
+    uint32_t apic_id;
+    bool enabled;
+    bool bsp;
+    uint8_t family;
+    uint8_t model;
+    uint8_t stepping;
 
     idt_entry_t *idt __aligned(16);
     idt_ptr_t idt_ptr;

--- a/include/setup.h
+++ b/include/setup.h
@@ -40,6 +40,8 @@ extern io_port_t com_ports[2];
 extern const char *kernel_cmdline;
 extern char cpu_identifier[49];
 
+/* Static declarations */
+
 static inline void get_com_ports(void) {
     memcpy((void *) com_ports, (void *) (BDA_COM_PORTS_ENTRY), sizeof(com_ports));
 
@@ -49,6 +51,11 @@ static inline void get_com_ports(void) {
     if (com_ports[1] == 0x0)
         com_ports[1] = COM2_PORT;
 }
+
+/* External declarations */
+
+extern unsigned get_bsp_cpu_id(void);
+extern void set_bsp_cpu_id(unsigned cpu_id);
 
 extern void zap_boot_mappings(void);
 

--- a/smp/mptables.c
+++ b/smp/mptables.c
@@ -210,11 +210,14 @@ static void process_mpc_entries(mpc_hdr_t *mpc_ptr) {
             percpu_t *percpu = get_percpu_page(nr_cpus++);
 
             percpu->apic_id = mpc_cpu->lapic_id;
-            percpu->enabled = mpc_cpu->en;
-            percpu->bsp = mpc_cpu->bsp;
+            percpu->enabled = !!mpc_cpu->en;
+            percpu->bsp = !!mpc_cpu->bsp;
             percpu->family = mpc_cpu->family;
             percpu->model = mpc_cpu->model;
             percpu->stepping = mpc_cpu->stepping;
+
+            if (percpu->bsp)
+                set_bsp_cpu_id(percpu->cpu_id);
 
             dump_mpc_processor_entry(mpc_cpu);
             entry_ptr += sizeof(*mpc_cpu);

--- a/smp/smp.c
+++ b/smp/smp.c
@@ -94,13 +94,13 @@ static __text_init void boot_cpu(unsigned int cpu) {
 }
 
 void __text_init init_smp(void) {
-    unsigned mp_nr_cpus = mptables_get_nr_cpus();
-    unsigned acpi_nr_cpus = acpi_get_nr_cpus();
-
-    nr_cpus = acpi_nr_cpus ?: mp_nr_cpus;
+    nr_cpus = acpi_get_nr_cpus();
     if (nr_cpus == 0) {
-        nr_cpus++;
-        return;
+        nr_cpus = mptables_get_nr_cpus();
+        if (nr_cpus == 0) {
+            nr_cpus++;
+            return;
+        }
     }
 
     printk("Initializing SMP support (CPUs: %u)\n", nr_cpus);


### PR DESCRIPTION
Add get_bsp_cpu_id() and set_bsp_cpu_id() helper functions.
Update bsp variable on BSP's percpu page upon both ACPI and MP tables
enumeration.

Do not use bitfield for storing percpu variables. And also rename id
to cpu_id.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

Part of: *Issue #113*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
