### PR TITLE
one-line-cr-bot: use production repo

### DIFF
--- a/.github/workflows/one-line-cr-bot.yml
+++ b/.github/workflows/one-line-cr-bot.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Get one-line-scan, the tool we will use for analysis
     - name: Get OneLineScan
-      run:  git clone -b one-line-cr-bot https://github.com/nmanthey/one-line-scan.git ../one-line-scan
+      run:  git clone -b one-line-cr-bot https://github.com/awslabs/one-line-scan.git ../one-line-scan
 
     # Check how repository is setup
     - name: Be Verbose about Git Setup


### PR DESCRIPTION
As the change has been merged by now, let's use the production
repository for the script.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
