### PR TITLE
APIC: Reimplement full Local APIC interface

### DIFF
--- a/arch/x86/apic.c
+++ b/arch/x86/apic.c
@@ -78,13 +78,26 @@ void apic_write(unsigned int reg, uint64_t val) {
         BUG();
 }
 
-void apic_icr_write(uint64_t val) {
+apic_icr_t apic_icr_read(void) {
+    apic_icr_t icr;
+
     if (apic_mode == APIC_MODE_XAPIC) {
-        apic_mmio_write(APIC_ICR1, (uint32_t)(val >> 32));
-        apic_mmio_write(APIC_ICR0, (uint32_t) val);
+        icr.icr0 = apic_read(APIC_ICR0);
+        icr.icr1 = apic_read(APIC_ICR1);
+    }
+    else if (apic_mode == APIC_MODE_X2APIC)
+        icr.reg = apic_read(APIC_ICR0);
+
+    return icr;
+}
+
+void apic_icr_write(const apic_icr_t *icr) {
+    if (apic_mode == APIC_MODE_XAPIC) {
+        apic_mmio_write(XAPIC_REG(APIC_ICR1), icr->icr0);
+        apic_mmio_write(XAPIC_REG(APIC_ICR0), icr->icr1);
     }
     else
-        apic_msr_write(MSR_X2APIC_REGS + (APIC_ICR0 >> 4), val);
+        apic_msr_write(X2APIC_REG(APIC_ICR0), icr->reg);
 }
 
 apic_mode_t apic_get_mode(void) { return apic_mode; }

--- a/arch/x86/apic.c
+++ b/arch/x86/apic.c
@@ -105,6 +105,7 @@ apic_mode_t apic_get_mode(void) { return apic_mode; }
 void init_apic(unsigned int cpu, apic_mode_t mode) {
     percpu_t *percpu = get_percpu_page(cpu);
     apic_base_t apic_base;
+    apic_spiv_t spiv;
 
     BUG_ON(mode < APIC_MODE_DISABLED);
 
@@ -149,5 +150,8 @@ void init_apic(unsigned int cpu, apic_mode_t mode) {
     if (apic_mode == APIC_MODE_XAPIC)
         vmap(apic_get_base(apic_base), apic_base.base, PAGE_ORDER_4K, L1_PROT);
 
-    apic_write(APIC_SPIV, APIC_SPIV_APIC_ENABLED | 0xff);
+    spiv.reg = apic_read(APIC_SPIV);
+    spiv.vector = 0xFF;
+    spiv.apic_enable = 1;
+    apic_write(APIC_SPIV, spiv.reg);
 }

--- a/arch/x86/apic.c
+++ b/arch/x86/apic.c
@@ -29,7 +29,7 @@
 #include <percpu.h>
 #include <processor.h>
 
-apic_mode_t apic_mode = APIC_MODE_UNKNOWN;
+static apic_mode_t apic_mode = APIC_MODE_UNKNOWN;
 
 static const char *apic_mode_names[] = {
     /* clang-format off */
@@ -87,6 +87,7 @@ void apic_icr_write(uint64_t val) {
         apic_msr_write(MSR_X2APIC_REGS + (APIC_ICR0 >> 4), val);
 }
 
+apic_mode_t apic_get_mode(void) { return apic_mode; }
 
 void init_apic(unsigned int cpu, apic_mode_t mode) {
     percpu_t *percpu = get_percpu_page(cpu);

--- a/common/setup.c
+++ b/common/setup.c
@@ -221,7 +221,7 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
         BUG();
     }
 
-    init_apic(APIC_MODE_XAPIC);
+    init_apic(get_bsp_cpu_id(), APIC_MODE_XAPIC);
 
     init_tasks();
 

--- a/include/arch/x86/apic.h
+++ b/include/arch/x86/apic.h
@@ -73,6 +73,335 @@ enum apic_mode {
 };
 typedef enum apic_mode apic_mode_t;
 
+union apic_base {
+    struct {
+        /* clang-format off */
+        uint64_t rsvd0 : 8,
+                 bsp   : 1,
+                 rsvd1 : 1,
+                 extd  : 1,
+                 en    : 1,
+                 base  : 24,
+                 rsvd2 : 28;
+        /* clang-format on */
+    } __packed;
+    uint64_t reg;
+};
+typedef union apic_base apic_base_t;
+
+union apic_spiv {
+    struct {
+        /* clang-format off */
+        uint32_t vector           : 8,
+                 apic_enable      : 1,
+                 focus_proc_check : 1,
+                 rsvd0            : 2,
+                 eoi_brdcast_supp : 1,
+                 rsvd1            : 19;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_spiv apic_spiv_t;
+
+union apic_id {
+    struct {
+        /* clang-format off */
+        uint32_t rsvd0         : 24,
+                 old_xapic_id  : 4,
+                 rsvd1         : 4;
+        /* clang-format on */
+    } __packed;
+    struct {
+        /* clang-format off */
+        uint32_t rsvd2     : 24,
+                 xapic_id  : 8;
+        /* clang-format on */
+    } __packed;
+    uint32_t x2apic_id;
+    uint32_t reg;
+};
+typedef union apic_id apic_id_t;
+
+union apic_version {
+    struct {
+        /* clang-format off */
+        uint32_t version          : 8,
+                 rsvd0            : 8,
+                 max_lvt_entry    : 8,
+                 eoi_brdcast_supp : 1,
+                 rsvd1            : 7;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_version apic_version_t;
+
+enum apic_trigger_mode {
+    APIC_TRIGGER_MODE_EDGE = 0x00,
+    APIC_TRIGGER_MODE_LEVEL = 0x01,
+};
+typedef enum apic_trigger_mode apic_trigger_mode_t;
+
+enum apic_deliv_status {
+    APIC_DELIV_STATUS_IDLE = 0x00,
+    APIC_DELIV_STATUS_SEND_PENDING = 0x01,
+};
+typedef enum apic_deliv_status apic_deliv_status_t;
+
+enum apic_lvt_mask {
+    APIC_LVT_UNMASKED = 0x00,
+    APIC_LVT_MASKED = 0x01,
+};
+typedef enum apic_lvt_mask apic_lvt_mask_t;
+
+enum apic_lvt_deliv_mode {
+    APIC_LVT_DELIV_MODE_FIXED = 0x00,
+    APIC_LVT_DELIV_MODE_SMI = 0x02,
+    APIC_LVT_DELIV_MODE_NMI = 0x04,
+    APIC_LVT_DELIV_MODE_INIT = 0x05,
+    APIC_LVT_DELIV_MODE_EXTINT = 0x07,
+};
+typedef enum apic_lvt_deliv_mode apic_lvt_deliv_mode_t;
+
+enum apic_lvt_timer_mode {
+    APIC_LVT_TIMER_ONE_SHOT = 0x00,
+    APIC_LVT_TIMER_PERIODIC = 0x01,
+    APIC_LVT_TIMER_TSC_DEADLINE = 0x10,
+};
+typedef enum apic_lvt_timer_mode apic_lvt_timer_mode_t;
+
+union apic_lvt_timer {
+    struct {
+        /* clang-format off */
+        uint32_t vector           : 8,
+                 rsvd0            : 4,
+                 deliv_status     : 1,
+                 rsvd1            : 3,
+                 mask             : 1,
+                 timer_mode       : 2,
+                 rsvd2            : 13;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_lvt_timer apic_lvt_timer_t;
+
+union apic_lvt_common {
+    struct {
+        /* clang-format off */
+        uint32_t vector           : 8,
+                 deliv_mode       : 3,
+                 rsvd0            : 1,
+                 deliv_status     : 1,
+                 rsvd1            : 3,
+                 mask             : 1,
+                 rsvd2            : 15;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_lvt_common apic_lvt_cmci_t;
+typedef union apic_lvt_common apic_lvt_pm_counters_t;
+typedef union apic_lvt_common apic_lvt_thermal_sensor_t;
+
+union apic_lvt_lint {
+    struct {
+        /* clang-format off */
+        uint32_t vector           : 8,
+                 deliv_mode       : 3,
+                 rsvd0            : 1,
+                 deliv_status     : 1,
+                 polarity         : 1,
+                 remote_irr       : 1,
+                 trigger_mode     : 1,
+                 mask             : 1,
+                 rsvd2            : 15;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_lvt_lint apic_lvt_lint_t;
+
+union apic_lvt_error {
+    struct {
+        /* clang-format off */
+        uint32_t vector           : 8,
+                 rsvd0            : 4,
+                 deliv_status     : 1,
+                 rsvd1            : 3,
+                 mask             : 1,
+                 rsvd2            : 15;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_lvt_error apic_lvt_error_t;
+
+union apic_esr {
+    struct {
+        /* clang-format off */
+        uint32_t send_checksum_err : 1,
+                 recv_checksum_err : 1,
+                 send_accept_err   : 1,
+                 recv_accept_err   : 1,
+                 redirectable_ipi  : 1,
+                 send_ill_vector   : 1,
+                 recv_ill_vector   : 1,
+                 ill_reg_address   : 1,
+                 rsvd0             : 24;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_esr apic_esr_t;
+
+enum apic_timer_divide {
+    APIC_TIMER_DIVIDE_BY_2 = 0x00,
+    APIC_TIMER_DIVIDE_BY_4 = 0x08,
+    APIC_TIMER_DIVIDE_BY_8 = 0x02,
+    APIC_TIMER_DIVIDE_BY_16 = 0x0a,
+    APIC_TIMER_DIVIDE_BY_32 = 0x01,
+    APIC_TIMER_DIVIDE_BY_64 = 0x09,
+    APIC_TIMER_DIVIDE_BY_128 = 0x03,
+    APIC_TIMER_DIVIDE_BY_1 = 0x0b,
+};
+typedef enum apic_timer_divide apic_timer_divide_t;
+
+union apic_timer_div_config {
+    struct {
+        /* clang-format off */
+        uint32_t divide_value : 4,
+                 rsvd0        : 28;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_timer_div_config apic_timer_div_config_t;
+
+enum apic_deliv_mode {
+    APIC_DELIV_MODE_FIXED = 0x00,
+    APIC_DELIV_MODE_LOWPRI = 0x01,
+    APIC_DELIV_MODE_SMI = 0x02,
+    APIC_DELIV_MODE_NMI = 0x04,
+    APIC_DELIV_MODE_INIT = 0x05,
+    APIC_DELIV_MODE_SIPI = 0x06,
+};
+typedef enum apic_deliv_mode apic_deliv_mode_t;
+
+enum apic_dest_mode {
+    APIC_DEST_MODE_PHYSICAL = 0x00,
+    APIC_DEST_MODE_LOGICAL = 0x01,
+};
+typedef enum apic_dest_mode apic_dest_mode_t;
+
+enum apic_icr_level {
+    APIC_ICR_LEVEL_DEASSERT = 0x00,
+    APIC_ICR_LEVEL_ASSERT = 0x01,
+};
+typedef enum apic_icr_level apic_icr_level_t;
+
+enum apic_dest_shorthand {
+    APIC_DEST_SHORTHAND_NONE = 0x00,
+    APIC_DEST_SHORTHAND_SELF = 0x01,
+    APIC_DEST_SHORTHAND_ALL = 0x10,
+    APIC_DEST_SHORTHAND_OTHERS = 0x11,
+};
+typedef enum apic_dest_shorthand apic_dest_shorthand_t;
+
+union apic_icr {
+    struct {
+        /* clang-format off */
+        uint64_t vector           : 8,
+                 deliv_mode       : 3,
+                 dest_mode        : 1,
+                 deliv_status     : 1,
+                 rsvd0            : 1,
+                 level            : 1,
+                 trigger_mode     : 1,
+                 rsvd1            : 2,
+                 dest_shorthand   : 2,
+                 rsvd2            : 36,
+                 xapic_dest       : 8;
+        /* clang-format on */
+    } __packed;
+    struct {
+        uint32_t rsvd3;
+        uint32_t x2apic_dest;
+    } __packed;
+    struct {
+        uint32_t icr0;
+        uint32_t icr1;
+    } __packed;
+    uint64_t reg;
+};
+typedef union apic_icr apic_icr_t;
+
+union apic_ldr {
+    struct {
+        /* clang-format off */
+        uint32_t rsvd0    : 24,
+                 xapic_id  : 8;
+        /* clang-format on */
+    } __packed;
+    uint32_t x2apic_id;
+    uint32_t reg;
+};
+typedef union apic_ldr apic_ldr_t;
+
+union apic_dfr {
+    struct {
+        /* clang-format off */
+        uint32_t rsvd0   : 28,
+                 model   : 4;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_dfr apic_dfr_t;
+
+union apic_priority_class {
+    struct {
+        /* clang-format off */
+        uint32_t sub_class : 4,
+                 class     : 4,
+                 rsvd0     : 24;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_priority_class apic_apr_t;
+typedef union apic_priority_class apic_tpr_t;
+typedef union apic_priority_class apic_ppr_t;
+
+union apic_request_register {
+    struct {
+        uint16_t rsvd0;
+        uint8_t bytes[30];
+    } __packed;
+    struct {
+        uint64_t rsvd1 : 16, qword0 : 48;
+        uint64_t qword1;
+        uint64_t qword2;
+        uint64_t qword3;
+    } __packed;
+    uint64_t reg[4];
+};
+typedef union apic_request_register apic_irr_t;
+typedef union apic_request_register apic_isr_t;
+typedef union apic_request_register apic_tmr_t;
+
+union apic_self_ipi {
+    struct {
+        /* clang-format off */
+        uint32_t vector           : 8,
+                 rsvd0            : 24;
+        /* clang-format on */
+    } __packed;
+    uint32_t reg;
+};
+typedef union apic_self_ipi apic_self_ipi_t;
+
 /* External declarations */
 
 extern apic_mode_t apic_mode;

--- a/include/arch/x86/apic.h
+++ b/include/arch/x86/apic.h
@@ -29,10 +29,7 @@
 #include <lib.h>
 #include <page.h>
 
-/* Local APIC definitions */
-#define APIC_SPIV_APIC_ENABLED 0x00100
-
-#define MSR_X2APIC_REGS        0x800U
+#define MSR_X2APIC_REGS 0x800U
 
 #ifndef __ASSEMBLY__
 

--- a/include/arch/x86/apic.h
+++ b/include/arch/x86/apic.h
@@ -462,10 +462,9 @@ typedef union apic_self_ipi apic_self_ipi_t;
 
 /* External declarations */
 
-extern apic_mode_t apic_mode;
-
 extern uint64_t apic_read(unsigned int reg);
 extern void apic_write(unsigned int reg, uint64_t val);
+extern apic_mode_t apic_get_mode(void);
 extern void apic_icr_write(uint64_t val);
 extern void init_apic(unsigned int cpu, apic_mode_t mode);
 

--- a/include/arch/x86/processor.h
+++ b/include/arch/x86/processor.h
@@ -91,8 +91,7 @@
 /*
  * Model Specific Registers (MSR)
  */
-#define MSR_APIC_BASE   0x0000001B
-#define MSR_X2APIC_REGS 0x00000800
+#define MSR_APIC_BASE 0x0000001B
 
 #define MSR_EFER   0xc0000080      /* Extended Feature Enable Register */
 #define EFER_SCE   (_U64(1) << 0)  /* SYSCALL Enable */

--- a/include/percpu.h
+++ b/include/percpu.h
@@ -25,6 +25,7 @@
 #ifndef KTF_PERCPU_H
 #define KTF_PERCPU_H
 
+#include <apic.h>
 #include <ktf.h>
 #include <lib.h>
 #include <list.h>
@@ -35,6 +36,7 @@ struct percpu {
 
     unsigned int cpu_id;
     uint32_t apic_id;
+    apic_base_t apic_base;
     bool enabled;
     bool bsp;
     uint8_t family;

--- a/smp/smp.c
+++ b/smp/smp.c
@@ -50,6 +50,7 @@ void __noreturn ap_startup(void) {
     write_sp(get_free_pages_top(PAGE_ORDER_2M, GFP_KERNEL));
 
     init_traps(ap_cpuid);
+    init_apic(ap_cpuid, apic_get_mode());
 
     ap_callin = true;
     smp_wmb();

--- a/smp/smp.c
+++ b/smp/smp.c
@@ -64,8 +64,7 @@ void __noreturn ap_startup(void) {
 }
 
 static __text_init void boot_cpu(unsigned int cpu) {
-    percpu_t *percpu = get_percpu_page(cpu);
-    uint64_t icr;
+    apic_icr_t icr;
 
     if (PERCPU_GET(bsp))
         return;
@@ -76,16 +75,22 @@ static __text_init void boot_cpu(unsigned int cpu) {
 
     dprintk("Starting AP: %u\n", cpu);
 
-    /* Set ICR2 part */
-    icr = (_ul(SET_APIC_DEST_FIELD(percpu->apic_id)) << 32);
+    icr = apic_icr_read();
+    apic_icr_set_dest(&icr, PERCPU_GET(apic_id));
 
     /* Wake up the secondary processor: INIT-SIPI-SIPI... */
+    icr.deliv_mode = APIC_DELIV_MODE_INIT;
     apic_wait_ready();
-    apic_icr_write(icr | APIC_DM_INIT);
+    apic_icr_write(&icr);
+
+    icr.deliv_mode = APIC_DELIV_MODE_SIPI;
+    icr.vector = GET_SIPI_VECTOR(ap_start);
     apic_wait_ready();
-    apic_icr_write(icr | (APIC_DM_STARTUP | GET_SIPI_VECTOR(ap_start)));
+    apic_icr_write(&icr);
+
     apic_wait_ready();
-    apic_icr_write(icr | (APIC_DM_STARTUP | GET_SIPI_VECTOR(ap_start)));
+    apic_icr_write(&icr);
+
     apic_wait_ready();
 
     while (!ap_callin)


### PR DESCRIPTION
This PR implements: *Issue #113*

*Description of changes:*

```
    apic: add proper handling of SPIV register
```

```
    apic: add proper R/W interface for ICR register
```

```
    smp: initialize APIC for each AP CPU
```

```
    apic: add apic_get_mode() function

    Make apic_mode global variable non-public and expose its value via
    interface.
```

```
    apic: reimplement entire APIC initialization

    Add support for changing APIC base address per CPU. Store current
    valie of APIC base address in Per-CPU structure of each CPU.
    In XAPIC mode, use that value to access MMIO address range of LAPIC.

    Use new structures and data types for R/W interface of both XAPIC and
    X2APIC modes.
    Fix incorrect implementation of R/W interface for X2APIC mode.

    Add CPU ID parameter to init_apic(), so it can be used by each AP too
    during bring-up.

    Update APIC base address and BSP flag of each CPU when calling
    init_apic(). Detect BSP from APIC base MSR.
```

```
    apic: add data types for XAPIC and X2APIC registers
```

```
    apic: add APIC structures and data types
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
