### PR TITLE
one-line-cr-bot: commenting PRs beta

### DIFF
--- a/.github/workflows/one-line-cr-bot.yml
+++ b/.github/workflows/one-line-cr-bot.yml
@@ -78,5 +78,7 @@ jobs:
         POST_TO_GITHUB_PR: true
         REPORT_NEW_ONLY: true
         VERBOSE: 0 # >0 shows all currently present defects as well
+        # We need access to the github token to be able to comment on the PR
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       # Be explicit about the tools to be used
       run: ../one-line-scan/one-line-cr-bot.sh -E infer -E cppcheck

--- a/.github/workflows/one-line-cr-bot.yml
+++ b/.github/workflows/one-line-cr-bot.yml
@@ -31,13 +31,13 @@ jobs:
         fetch-depth: 0
 
     # one-line-cr-bot.sh will get infer and cppcheck, if not available
-    - name: Install CppCheck Package
+    - name: Install Required Packages
       env:
         # This is needed in addition to -yq to prevent apt-get from asking for user input
         DEBIAN_FRONTEND: noninteractive
-      # [ACTION REQUIRED] Add your build dependencies here, drop cppcheck to get latest cppcheck
+      # [ACTION REQUIRED] Add your build dependencies here
       run: |
-        sudo apt-get install -y cppcheck
+        sudo apt-get install -y python3-github
 
     # Get the compare remote
     - name: Setup Compare Remote
@@ -48,7 +48,7 @@ jobs:
 
     # Get one-line-scan, the tool we will use for analysis
     - name: Get OneLineScan
-      run:  git clone -b one-line-cr-bot https://github.com/nmanthey/one-line-scan.git ../one-line-scan
+      run:  git clone -b comment-prs https://github.com/nmanthey/one-line-scan.git ../one-line-scan
 
     # Check how repository is setup
     - name: Be Verbose about Git Setup
@@ -71,9 +71,11 @@ jobs:
         # Additional Infer parameters, do not use e.g. --pulse
         INFER_ANALYSIS_EXTRA_ARGS: "--bufferoverrun"
         # These settings are more preferences, and not directly related to your project
-        # Set INSTALL_MISSING to false, if ALL targetted tools are already present
+        # Set INSTALL_MISSING to false, if ALL targeted tools are already present
+        IGNORE_ERRORS: false
         INSTALL_MISSING: true
         OVERRIDE_ANALYSIS_ERROR: true
+        POST_TO_GITHUB_PR: true
         REPORT_NEW_ONLY: true
         VERBOSE: 0 # >0 shows all currently present defects as well
       # Be explicit about the tools to be used

--- a/.github/workflows/one-line-cr-bot.yml
+++ b/.github/workflows/one-line-cr-bot.yml
@@ -11,7 +11,7 @@
 name: One Line CR Bot
 
 on:
-  pull_request:
+  pull_request_target:
     # [ACTION REQUIRED] Set the branch you want to analyze PRs for
     branches: [ mainline ]
 

--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -146,12 +146,16 @@ void *vmap(void *va, mfn_t mfn, unsigned int order, unsigned long flags) {
     mfn_t l1t_mfn, l2t_mfn, l3t_mfn;
     pgentry_t *tab, *entry;
 
+    /* test code analysis
     if (!va || _ul(va) & ~PAGE_MASK)
         return NULL;
+    */
 
     dprintk("%s: va: %p mfn: 0x%lx (order: %u)\n", __func__, va, mfn, order);
 
+    /* test code analysis
     spin_lock(&lock);
+    */
 
 #if defined(__x86_64__)
     l3t_mfn = get_pgentry_mfn(get_cr3_mfn(&cr3), l4_table_index(va), L4_PROT_USER);


### PR DESCRIPTION
The next feature is to comment on PRs instead of writing defects to the
workflow output. To do so, we need to use the new development branch.
Furthermore, we need github support in python. Finally, let's not use
the system cppcheck, but the most recent one.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

*Issue #, if available:* #63 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
