### PR TITLE
tools: Add workflow to run one-line-scan locally in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,3 +201,13 @@ dockerimage:
 docker%: dockerimage
 	@echo "running target '$(strip $(subst :,, $*))' in docker"
 	@ docker run -it -e UNITTEST=$(UNITTEST) -v $(PWD):$(PWD)$(DOCKER_MOUNT_OPTS) -w $(PWD) $(DOCKERIMAGE) bash -c "make -j $(strip $(subst :,, $*))"
+
+.PHONY: onelinescan
+onelinescan:
+	@echo "scanning current working directory with one-line-scan"
+	@ docker run -it -e BASE_COMMIT=origin/mainline \
+		-e REPORT_NEW_ONLY=true -e OVERRIDE_ANALYSIS_ERROR=true \
+		-e INFER_ANALYSIS_EXTRA_ARGS="--bufferoverrun" \
+		-e CPPCHECK_EXTRA_ARG=" --enable=style --enable=performance --enable=information --enable=portability" \
+		-e VERBOSE=0 -e BUILD_COMMAND="make -B all" \
+		-v $(PWD):$(PWD)$(DOCKER_MOUNT_OPTS) -w $(PWD) ktf-one-line-scan

--- a/README.md
+++ b/README.md
@@ -149,6 +149,35 @@ This has to be done only once.
 make style
 ```
 
+### Running the one-line-scan workflow locally
+
+#### Build the `ktf-one-line-scan` container
+
+* first, download the `one-line-scan` base image
+```bash
+docker build -t one-line-scan \
+    https://raw.githubusercontent.com/awslabs/one-line-scan/master/tools/Dockerfile
+```
+
+* create the KTF specific one-line-scan image, including necessary tools for building
+```
+ docker build -t ktf-one-line-scan \
+    --build-arg USER_ID=$(id -u) \
+    --build-arg GROUP_ID=$(id -g) \
+    --build-arg USER=$USER \
+    --file tools/docker/OnelineScanDockerfile .
+```
+
+This has to be done only once.
+
+#### Scan your current working directory
+
+* per default, one-line-scan scans against the diff between `HEAD` and `origin/mainline` commit
+
+```bash
+make onelinescan
+```
+
 ## Credits and Attributions
 
 * Parts of the KTF project are inspired by and based on XTF project [1] developed by Andrew Cooper of Citrix.

--- a/tools/docker/OnelineScanDockerfile
+++ b/tools/docker/OnelineScanDockerfile
@@ -1,0 +1,17 @@
+FROM one-line-scan:latest
+
+ARG USER=onelinescan
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y \
+    -o Dpkg::Options::="--force-confdef" \
+    -o Dpkg::Options::="--force-confold" \
+    install grub2 python gcc make xorriso qemu-utils
+
+# Create proper users so that our build artifacts
+# can be shared with the outside user
+# https://vsupalov.com/docker-shared-permissions/
+RUN addgroup --gid $GROUP_ID $USER
+RUN useradd --no-log-init --uid $USER_ID --gid $GROUP_ID $USER
+USER $USER


### PR DESCRIPTION
Since we started using one-line-scan[1] against each PR, it makes sense to have
same workflow available locally.

This commit adds the necessary Dockerfile and documentation about how to setup
one-line-scan locally and how to run this on your current working directory.

[1] https://github.com/awslabs/one-line-scan

Signed-off-by: Martin Mazein <amazein@amazon.de>

*Issue #, if available:*

*Description of changes:*

Testing done:
- running the build command succeeds
```
$ make onelinescan
scanning current working directory with one-line-scan
Run diff analysis with given base commit mainline (9b390ef4d4f042f66a1cefcedf84137b7c746678)
Spotted 36 findings for base, and 36 for current commit

All findings worth reporting as introduced:

Did not detect relevant findings
```

- adding a simple error, triggers an error locally:
```
$ make onelinescan
scanning current working directory with one-line-scan
Run diff analysis with given base commit mainline (9b390ef4d4f042f66a1cefcedf84137b7c746678)
Spotted 36 findings for base, and 37 for current commit

All findings worth reporting as introduced:
include/cpuid.h:49: (style:knownConditionTrueFalse) Condition 'z+y>y' is always true

Full stderr:
stderr.log:Versions of used tools:
stderr.log:Infer version v1.0.0
stderr.log:Copyright 2009 - present Facebook. All Rights Reserved.
stderr.log:Cppcheck 1.90
stderr.log:Failed infer analysis (on mainline), received exit code: 1
stderr.log:Failed CppCheck analysis (on mainline, might mean defects have been spotted), received exit code: 1
stderr.log:Failed infer analysis (on local_oneline), received exit code: 1
stderr.log:Failed CppCheck analysis (on local_oneline, might mean defects have been spotted), received exit code: 1
stderr.log:/opt/one-line-scan/one-line-cr-bot.sh: cleanup_handler() invoked, exit status 1
make: *** [onelinescan] Error 1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
