### PR TITLE
GCC10 Compile Fix

### DIFF
--- a/include/drivers/keyboard.h
+++ b/include/drivers/keyboard.h
@@ -38,7 +38,7 @@
 
 #define KEYBOARD_STATUS_OUT_FULL 0x01 /* bit set when the keyboard buffer is full */
 
-enum {
+typedef enum {
     KEYBOARD_CMD_WRITE_CONFIGURATION = 0x60, /* Write configuration byte */
     KEYBOARD_CMD_READ_CONFIGURATION = 0x20,  /* Read configuration byte */
     KEYBOARD_CMD_SELF_TEST = 0xAA,
@@ -48,8 +48,7 @@ enum {
     KEYBOARD_CMD_DISABLE_PORT_2 = 0xA7,
     KEYBOARD_CMD_ENABLE_PORT_1 = 0xAE,
     KEYBOARD_CMD_ENABLE_PORT_2 = 0xA8,
-} keyboard_cmd;
-typedef enum keyboard_cmd keyboard_cmd_t;
+} keyboard_cmd_t;
 
 #define KEYBOARD_RES_SELF_TEST 0x55
 


### PR DESCRIPTION
GCC10 made `-fno-common` a default flag and for a slightly confusing reason
this leads to the compiler complaining about multiple definitions of the
keyboard_cmd enum. Work around that by merging the declaration of the enum into
the typedef of `keyboard_cmd_t`.

Ref.: https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common

Signed-off-by: Bjoern Doebel <bjoern.doebel@gmail.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
