### PR TITLE
Build KTF without using host system's libc headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ SYSTEM := MACOS
 endif
 endif
 
+ifeq ($(CC),cc) # overwrite on default, otherwise use whatever is in the CC env variable
 CC := gcc
+endif
 LD := ld
 
 NM := nm

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ cscope:
 .PHONY: style
 style:
 	@echo "STYLE"
-	$(VERBOSE) docker run --rm --workdir /src -v $(PWD):/src clang-format-lint --clang-format-executable /clang-format/clang-format10 \
+	$(VERBOSE) docker run --rm --workdir /src -v $(PWD):/src$(DOCKER_MOUNT_OPTS) clang-format-lint --clang-format-executable /clang-format/clang-format10 \
           -r $(SOURCES) $(HEADERS) | grep -v -E '^Processing [0-9]* files:' | patch -s -p1 ||:
 
 DOCKERFILE  := $(shell find $(ROOT) -type f -name Dockerfile)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ COMMON_FLAGS += -DKTF_UNIT_TEST
 endif
 
 AFLAGS  := $(COMMON_FLAGS) -D__ASSEMBLY__ -nostdlib -nostdinc
-CFLAGS  := $(COMMON_FLAGS) -std=gnu99 -O3 -g -Wall -Wextra -ffreestanding
+CFLAGS  := $(COMMON_FLAGS) -std=gnu99 -O3 -g -Wall -Wextra -ffreestanding -nostdlib -nostdinc
+CFLAGS  += -Iinclude
 CFLAGS  += -mno-red-zone -mno-mmx -mno-sse -mno-sse2
 CFLAGS  += -fno-stack-protector -fno-exceptions -fno-builtin
 CFLAGS  += -mcmodel=kernel -fno-pic -fno-asynchronous-unwind-tables -fno-unwind-tables

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -94,7 +94,7 @@ typedef uint64_t off_t;
 
 #define memberof(type, member) (((type *) 0)->member)
 #ifndef offsetof
-#define offsetof(type, member) ((off_t) &memberof((type), member))
+#define offsetof(type, member) ((off_t) &memberof(type, member))
 #endif
 
 #define BUILD_BUG_ON(cond) ({ _Static_assert(!(cond), "!(" STR(cond) ")"); })

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -138,4 +138,6 @@ typedef uint64_t off_t;
 
 #define TOKEN_OR(t, ...) COUNT_MACRO_ARGS(TOKEN_OR, t, ##__VA_ARGS__)
 
+#define __always_inline __inline __attribute__((always_inline))
+
 #endif /* KTF_COMPILER_H */

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -1,0 +1,19 @@
+#pragma once
+
+typedef __INT64_TYPE__ int64_t;
+typedef __INT32_TYPE__ int32_t;
+typedef __INT16_TYPE__ int16_t;
+typedef __INT8_TYPE__ int8_t;
+typedef int64_t intmax_t;
+
+typedef __UINT64_TYPE__ uint64_t;
+typedef __UINT32_TYPE__ uint32_t;
+typedef __UINT16_TYPE__ uint16_t;
+typedef __UINT8_TYPE__ uint8_t;
+typedef uint64_t uintmax_t;
+
+typedef __SIZE_TYPE__ size_t;
+
+typedef __INTPTR_TYPE__ ptr_t;
+typedef __UINTPTR_TYPE__ uintptr_t;
+typedef __PTRDIFF_TYPE__ ptrdiff_t;

--- a/include/limits.h
+++ b/include/limits.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define ULONG_MAX __UINT64_MAX__
+#define LONG_MAX  __INT64_MAX__
+#define LONG_MIN  (-LONG_MAX - 1L)

--- a/include/stdarg.h
+++ b/include/stdarg.h
@@ -1,0 +1,7 @@
+#pragma once
+
+typedef __builtin_va_list va_list;
+
+#define va_start __builtin_va_start
+#define va_end   __builtin_va_end
+#define va_arg   __builtin_va_arg

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define bool _Bool
+#define true 1
+#define false 0

--- a/include/stddef.h
+++ b/include/stddef.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define NULL ((void *) 0)

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <inttypes.h>


### PR DESCRIPTION
Fixes #89 

Make necessary changes so that we can compile KTF without accidentally pulling in the build system's type definitions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
