### PR TITLE
Fix clang error

### DIFF
--- a/arch/x86/apic.c
+++ b/arch/x86/apic.c
@@ -91,6 +91,8 @@ apic_icr_t apic_icr_read(void) {
     }
     else if (apic_mode == APIC_MODE_X2APIC)
         icr.reg = apic_read(APIC_ICR0);
+    else
+        BUG();
 
     return icr;
 }


### PR DESCRIPTION
As we now can build with clang, I did so and ran into an error where clang
complained about a potential uninitialized return value. Fix this.

Signed-off-by: Bjoern Doebel <bjoern.doebel@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
