### PR TITLE
pagetable fixes: zero cr3 page and lower 1MB kernel va range

### DIFF
--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -115,8 +115,13 @@ static void *init_map_mfn(mfn_t mfn) {
 }
 
 static mfn_t get_cr3_mfn(cr3_t *cr3_entry) {
-    if (mfn_invalid(cr3_entry->mfn))
+    void *cr3_mapped = NULL;
+
+    if (mfn_invalid(cr3_entry->mfn)) {
         cr3_entry->mfn = get_free_frame();
+        cr3_mapped = init_map_mfn(cr3_entry->mfn);
+        memset(cr3_mapped, 0, PAGE_SIZE);
+    }
 
     return cr3_entry->mfn;
 }

--- a/mm/pmm.c
+++ b/mm/pmm.c
@@ -63,23 +63,23 @@ static size_t frames_count[MAX_PAGE_ORDER + 1];
 
 addr_range_t addr_ranges[] = {
     /* clang-format off */
-    IDENT_RANGE( "Low memory",  L1_PROT_RO,      0x0,               MB(1)           ),
-    IDENT_RANGE( ".text.init",  L1_PROT_RO,      __start_text_init, __end_text_init ),
-    IDENT_RANGE( ".data.init",  L1_PROT,         __start_data_init, __end_data_init ),
-    IDENT_RANGE( ".bss.init",   L1_PROT,         __start_bss_init,  __end_bss_init  ),
+    IDENT_RANGE( "Low memory",  L1_PROT_RO,      0x0,                   MB(1)           ),
+    IDENT_RANGE( ".text.init",  L1_PROT_RO,      __start_text_init,     __end_text_init ),
+    IDENT_RANGE( ".data.init",  L1_PROT,         __start_data_init,     __end_data_init ),
+    IDENT_RANGE( ".bss.init",   L1_PROT,         __start_bss_init,      __end_bss_init  ),
 
-    IDENT_RANGE( ".rmode",      L1_PROT,         __start_rmode,     __end_rmode     ),
+    IDENT_RANGE( ".rmode",      L1_PROT,         __start_rmode,         __end_rmode     ),
 
-    USER_RANGE( ".text.user",   L1_PROT_USER_RO, __start_text_user, __end_text_user ),
-    USER_RANGE( ".data.user",   L1_PROT_USER,    __start_data_user, __end_data_user ),
-    USER_RANGE( ".bss.user",    L1_PROT_USER,    __start_bss_user,  __end_bss_user  ),
+    USER_RANGE( ".text.user",   L1_PROT_USER_RO, __start_text_user,     __end_text_user ),
+    USER_RANGE( ".data.user",   L1_PROT_USER,    __start_data_user,     __end_data_user ),
+    USER_RANGE( ".bss.user",    L1_PROT_USER,    __start_bss_user,      __end_bss_user  ),
 
-    KERNEL_RANGE( "Low memory", L1_PROT,         0x0,               MB(1)           ),
-    KERNEL_RANGE( ".text",      L1_PROT_RO,      __start_text,      __end_text      ),
-    KERNEL_RANGE( ".data",      L1_PROT,         __start_data,      __end_data      ),
-    KERNEL_RANGE( ".bss",       L1_PROT,         __start_bss,       __end_bss       ),
-    KERNEL_RANGE( ".rodata",    L1_PROT_RO,      __start_rodata,    __end_rodata    ),
-    KERNEL_RANGE( ".symbols",   L1_PROT_RO,      __start_symbols,   __end_symbols   ),
+    KERNEL_RANGE( "Low memory", L1_PROT,         0x0 + VIRT_KERNEL_BASE, MB(1) + VIRT_KERNEL_BASE),
+    KERNEL_RANGE( ".text",      L1_PROT_RO,      __start_text,           __end_text      ),
+    KERNEL_RANGE( ".data",      L1_PROT,         __start_data,           __end_data      ),
+    KERNEL_RANGE( ".bss",       L1_PROT,         __start_bss,            __end_bss       ),
+    KERNEL_RANGE( ".rodata",    L1_PROT_RO,      __start_rodata,         __end_rodata    ),
+    KERNEL_RANGE( ".symbols",   L1_PROT_RO,      __start_symbols,        __end_symbols   ),
     /* clang-format on */
 
     {0x0} /* NULL array terminator */


### PR DESCRIPTION
commit bb24de2f3f51a9b325b15c44d9725cefa35eb40b did memset for page
frame allocations but cr3 page memset zero  was missed. This commit
fixes that. Lower 1MB range for kernel VA was coming out to be
80000000-80000000 but it needs to 0xffffffff80000000-ffffffff80100000.

Signed-off-by: Deepak Gupta <dkgupta@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
