### PR TITLE
acpi: checksum fix when xsdt has entries

### DIFF
--- a/common/acpi.c
+++ b/common/acpi.c
@@ -188,7 +188,7 @@ static xsdt_t *acpi_find_xsdt(const rsdp_rev2_t *rsdp) {
     if (XSDT_SIGNATURE != xsdt->header.signature)
         goto error;
 
-    if (get_checksum(xsdt, tab_len) != 0x0)
+    if (get_checksum(xsdt, xsdt->header.length) != 0x0)
         goto error;
 
     acpi_dump_table(xsdt, &xsdt->header);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
According to the ACPI manual, XSDT can contain additional entries (pointers) as part of the header. Those must be included when computing the checksum.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
