### PR TITLE
Fix drivers and SMP initialization on odd hardware

### DIFF
--- a/common/percpu.c
+++ b/common/percpu.c
@@ -58,3 +58,10 @@ percpu_t *get_percpu_page(unsigned int cpu) {
     list_add(&percpu->list, &percpu_frames);
     return percpu;
 }
+
+void for_each_percpu(void (*func)(percpu_t *percpu)) {
+    percpu_t *percpu;
+
+    list_for_each_entry (percpu, &percpu_frames, list)
+        func(percpu);
+}

--- a/common/setup.c
+++ b/common/setup.c
@@ -54,6 +54,15 @@
 bool opt_debug = false;
 bool_cmd("debug", opt_debug);
 
+bool opt_keyboard = false;
+bool_cmd("keyboard", opt_keyboard);
+
+bool opt_pit = false;
+bool_cmd("pit", opt_pit);
+
+bool opt_apic_timer = false;
+bool_cmd("apic_timer", opt_apic_timer);
+
 io_port_t com_ports[2] = {COM1_PORT, COM2_PORT};
 
 static unsigned bsp_cpu_id = 0;
@@ -202,11 +211,8 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
 
     /* Setup final pagetables */
     init_pagetables();
-
     write_cr3(cr3.paddr);
-
     write_sp(get_free_pages_top(PAGE_ORDER_2M, GFP_KERNEL));
-
     if (opt_debug)
         dump_pagetables();
 
@@ -234,11 +240,14 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     uart_input_init(get_bsp_cpu_id());
 
     /* Initialize timers */
-    init_pit(get_bsp_cpu_id());
-    init_apic_timer();
+    if (opt_pit)
+        init_pit(get_bsp_cpu_id());
+    if (opt_apic_timer)
+        init_apic_timer();
 
     /* Initialize keyboard */
-    init_keyboard(get_bsp_cpu_id());
+    if (opt_keyboard)
+        init_keyboard(get_bsp_cpu_id());
 
     /* Jump from .text.init section to .text */
     asm volatile("push %0; ret" ::"r"(&kernel_main));

--- a/drivers/keyboard.c
+++ b/drivers/keyboard.c
@@ -82,7 +82,7 @@ void init_keyboard(uint8_t dst_cpus) {
 
     dual_channel = current_status.clock2 == 0 ? 1 : 0; /* second channel enabled if 0 */
 
-    printk("Current PS/2 status before: %x\n", current_status.config);
+    dprintk("Current PS/2 status before: %x\n", current_status.config);
 
     /* Disable IRQs and translation */
     current_status.port1_int = 0;
@@ -93,8 +93,8 @@ void init_keyboard(uint8_t dst_cpus) {
     outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_WRITE_CONFIGURATION);
     outb(KEYBOARD_PORT_DATA, current_status.config);
 
-    printk("Current PS/2 status after mods: %x\n", current_status.config);
-    printk("PS/2 dual channel? %d\n", dual_channel);
+    dprintk("Current PS/2 status after mods: %x\n", current_status.config);
+    dprintk("PS/2 dual channel? %d\n", dual_channel);
 
     /* Controller self test */
     outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_SELF_TEST);
@@ -122,7 +122,7 @@ void init_keyboard(uint8_t dst_cpus) {
         port2 = inb(KEYBOARD_PORT_DATA) == 0 ? 1 : 0;
     }
 
-    printk("Port1 available? %d - port2 available? %d\n", port1, port2);
+    dprintk("Port1 available? %d - port2 available? %d\n", port1, port2);
     if (!port1 && !port2) {
         printk("No available PS/2 working ports\n");
         return;
@@ -130,7 +130,7 @@ void init_keyboard(uint8_t dst_cpus) {
 
     /* Enable devices */
     if (port1) {
-        printk("Keyboard: enabling first channel\n");
+        dprintk("Keyboard: enabling first channel\n");
         current_status.port1_int = 1;
         current_status.clock2 = 1; /* disable second port clock */
         current_status.translation = 1;
@@ -142,7 +142,7 @@ void init_keyboard(uint8_t dst_cpus) {
         outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_ENABLE_PORT_1);
     }
     else {
-        printk("Keyboard: enabling second channel\n");
+        dprintk("Keyboard: enabling second channel\n");
         current_status.port2_int = 1;
         outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_WRITE_CONFIGURATION);
         outb(KEYBOARD_PORT_DATA, current_status.config);

--- a/include/lib.h
+++ b/include/lib.h
@@ -28,6 +28,7 @@
 #include <asm-macros.h>
 #include <console.h>
 #include <ktf.h>
+#include <processor.h>
 #include <segment.h>
 
 #define min(a, b)                                                                        \
@@ -232,6 +233,10 @@ static inline unsigned long read_cr0(void) {
     return cr0;
 }
 
+static inline void write_cr0(unsigned long cr0) {
+    asm volatile("mov %0, %%cr0" ::"r"(cr0));
+}
+
 static inline unsigned long read_cr2(void) {
     unsigned long cr2;
 
@@ -393,6 +398,11 @@ static inline unsigned long ipow(int base, unsigned int exp) {
     }
 
     return result;
+}
+
+static inline void enable_sse(void) {
+    write_cr0((read_cr0() & ~X86_CR0_EM) | X86_CR0_MP);
+    write_cr4(read_cr4() | X86_CR4_OSFXSR | X86_CR4_OSXMMEXCPT);
 }
 
 /* External declarations */

--- a/include/percpu.h
+++ b/include/percpu.h
@@ -125,5 +125,6 @@ typedef struct percpu percpu_t;
 
 extern void init_percpu(void);
 extern percpu_t *get_percpu_page(unsigned int cpu);
+extern void for_each_percpu(void (*func)(percpu_t *percpu));
 
 #endif /* KTF_PERCPU_H */

--- a/tests/test.c
+++ b/tests/test.c
@@ -63,16 +63,12 @@ static void cpu_freq_expect(const char *cpu_str, uint64_t expectation) {
     printk("Got CPU string '%s' and frequency '%llu'\n", cpu_str, result);
     return;
 }
-#endif
 
 static int __user_text func(void *arg) { return 0; }
 
-void test_main(void) {
-    printk("\nTest:\n");
-
+static int ktf_unit_tests(void) {
     usermode_call(func, NULL);
 
-#ifdef KTF_UNIT_TEST
     printk("\nLet the UNITTESTs begin\n");
     printk("Commandline parsing: %s\n", kernel_cmdline);
 
@@ -139,7 +135,17 @@ void test_main(void) {
     cpu_freq_expect("AMD Ryzen Threadripper 1950X 16-Core Processor", 0);
     cpu_freq_expect("Prototyp Amazing Foo One @ 1GHz", 1000000000);
     cpu_freq_expect("Prototyp Amazing Foo Two @ 1.00GHz", 1000000000);
+
+    return 0;
+}
+#else
+static int ktf_unit_tests(void) { return 0; }
 #endif
+
+void test_main(void) {
+    printk("\nTest:\n");
+
+    ktf_unit_tests();
 
     wait_for_all_tasks();
 


### PR DESCRIPTION
On some platforms the APIC IDs of APs are not sequential. Also, make timers and keyboard optional.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
