### PR TITLE
Fix write_sp() to be a macro and other build time optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ AFLAGS  := $(COMMON_FLAGS) -D__ASSEMBLY__ -nostdlib -nostdinc
 CFLAGS  := $(COMMON_FLAGS) -std=gnu99 -O3 -g -Wall -Wextra -ffreestanding -nostdlib -nostdinc
 CFLAGS  += -Iinclude
 CFLAGS  += -mno-red-zone -mno-mmx -mno-sse -mno-sse2
-CFLAGS  += -fno-stack-protector -fno-exceptions -fno-builtin
+CFLAGS  += -fno-stack-protector -fno-exceptions -fno-builtin -fomit-frame-pointer -fcf-protection="none"
 CFLAGS  += -mcmodel=kernel -fno-pic -fno-asynchronous-unwind-tables -fno-unwind-tables
 CFLAGS  += -Wno-unused-parameter -Wno-address-of-packed-member
 CFLAGS  += -Werror
@@ -135,7 +135,7 @@ $(TARGET): $(PFMLIB_ARCHIVE) $(OBJS) $(PREP_LINK_SCRIPT)
 
 $(PFMLIB_ARCHIVE): $(PFMLIB_TARBALL)
 	@echo "UNTAR pfmlib"
-	# untar tarball and apply the patch 
+	# untar tarball and apply the patch
 	cd $(PFMLIB_DIR) &&\
 	$(TAR_CMD) $(PFMLIB_TARBALL) $(PFMLIB_UNTAR_FILES) -C ./ &&\
 	$(PATCH) -p1 < $(PFMLIB_PATCH_FILE) &&\

--- a/common/kernel.c
+++ b/common/kernel.c
@@ -51,7 +51,7 @@ static void echo_loop(void) {
     }
 }
 
-void kernel_main(void) {
+void __naked kernel_main(void) {
     printk("\nKTF - Kernel Test Framework!\n\n");
 
     if (kernel_cmdline)

--- a/common/percpu.c
+++ b/common/percpu.c
@@ -58,3 +58,10 @@ percpu_t *get_percpu_page(unsigned int cpu) {
     list_add(&percpu->list, &percpu_frames);
     return percpu;
 }
+
+void for_each_percpu(void (*func)(percpu_t *percpu)) {
+    percpu_t *percpu;
+
+    list_for_each_entry (percpu, &percpu_frames, list)
+        func(percpu);
+}

--- a/common/setup.c
+++ b/common/setup.c
@@ -212,7 +212,7 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     /* Setup final pagetables */
     init_pagetables();
     write_cr3(cr3.paddr);
-    write_sp(get_free_pages_top(PAGE_ORDER_2M, GFP_KERNEL));
+    WRITE_SP(get_free_pages_top(PAGE_ORDER_2M, GFP_KERNEL));
     if (opt_debug)
         dump_pagetables();
 

--- a/common/setup.c
+++ b/common/setup.c
@@ -54,6 +54,15 @@
 bool opt_debug = false;
 bool_cmd("debug", opt_debug);
 
+bool opt_keyboard = false;
+bool_cmd("keyboard", opt_keyboard);
+
+bool opt_pit = false;
+bool_cmd("pit", opt_pit);
+
+bool opt_apic_timer = false;
+bool_cmd("apic_timer", opt_apic_timer);
+
 io_port_t com_ports[2] = {COM1_PORT, COM2_PORT};
 
 static unsigned bsp_cpu_id = 0;
@@ -202,11 +211,8 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
 
     /* Setup final pagetables */
     init_pagetables();
-
     write_cr3(cr3.paddr);
-
     write_sp(get_free_pages_top(PAGE_ORDER_2M, GFP_KERNEL));
-
     if (opt_debug)
         dump_pagetables();
 
@@ -234,11 +240,14 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     uart_input_init(get_bsp_cpu_id());
 
     /* Initialize timers */
-    init_pit(get_bsp_cpu_id());
-    init_apic_timer();
+    if (opt_pit)
+        init_pit(get_bsp_cpu_id());
+    if (opt_apic_timer)
+        init_apic_timer();
 
     /* Initialize keyboard */
-    init_keyboard(get_bsp_cpu_id());
+    if (opt_keyboard)
+        init_keyboard(get_bsp_cpu_id());
 
     /* Jump from .text.init section to .text */
     asm volatile("push %0; ret" ::"r"(&kernel_main));

--- a/drivers/keyboard.c
+++ b/drivers/keyboard.c
@@ -82,7 +82,7 @@ void init_keyboard(uint8_t dst_cpus) {
 
     dual_channel = current_status.clock2 == 0 ? 1 : 0; /* second channel enabled if 0 */
 
-    printk("Current PS/2 status before: %x\n", current_status.config);
+    dprintk("Current PS/2 status before: %x\n", current_status.config);
 
     /* Disable IRQs and translation */
     current_status.port1_int = 0;
@@ -93,8 +93,8 @@ void init_keyboard(uint8_t dst_cpus) {
     outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_WRITE_CONFIGURATION);
     outb(KEYBOARD_PORT_DATA, current_status.config);
 
-    printk("Current PS/2 status after mods: %x\n", current_status.config);
-    printk("PS/2 dual channel? %d\n", dual_channel);
+    dprintk("Current PS/2 status after mods: %x\n", current_status.config);
+    dprintk("PS/2 dual channel? %d\n", dual_channel);
 
     /* Controller self test */
     outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_SELF_TEST);
@@ -122,7 +122,7 @@ void init_keyboard(uint8_t dst_cpus) {
         port2 = inb(KEYBOARD_PORT_DATA) == 0 ? 1 : 0;
     }
 
-    printk("Port1 available? %d - port2 available? %d\n", port1, port2);
+    dprintk("Port1 available? %d - port2 available? %d\n", port1, port2);
     if (!port1 && !port2) {
         printk("No available PS/2 working ports\n");
         return;
@@ -130,7 +130,7 @@ void init_keyboard(uint8_t dst_cpus) {
 
     /* Enable devices */
     if (port1) {
-        printk("Keyboard: enabling first channel\n");
+        dprintk("Keyboard: enabling first channel\n");
         current_status.port1_int = 1;
         current_status.clock2 = 1; /* disable second port clock */
         current_status.translation = 1;
@@ -142,7 +142,7 @@ void init_keyboard(uint8_t dst_cpus) {
         outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_ENABLE_PORT_1);
     }
     else {
-        printk("Keyboard: enabling second channel\n");
+        dprintk("Keyboard: enabling second channel\n");
         current_status.port2_int = 1;
         outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_WRITE_CONFIGURATION);
         outb(KEYBOARD_PORT_DATA, current_status.config);

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -62,6 +62,7 @@ typedef uint64_t off_t;
 #define __weak       __attribute__((__weak__))
 #define __noinline   __attribute__((__noinline__))
 #define __section(s) __attribute__((__section__(s)))
+#define __naked      __attribute__((naked))
 
 #define UNREACHABLE()                                                                    \
     do {                                                                                 \

--- a/include/lib.h
+++ b/include/lib.h
@@ -28,6 +28,7 @@
 #include <asm-macros.h>
 #include <console.h>
 #include <ktf.h>
+#include <processor.h>
 #include <segment.h>
 
 #define min(a, b)                                                                        \
@@ -232,6 +233,10 @@ static inline unsigned long read_cr0(void) {
     return cr0;
 }
 
+static inline void write_cr0(unsigned long cr0) {
+    asm volatile("mov %0, %%cr0" ::"r"(cr0));
+}
+
 static inline unsigned long read_cr2(void) {
     unsigned long cr2;
 
@@ -393,6 +398,11 @@ static inline unsigned long ipow(int base, unsigned int exp) {
     }
 
     return result;
+}
+
+static inline void enable_sse(void) {
+    write_cr0((read_cr0() & ~X86_CR0_EM) | X86_CR0_MP);
+    write_cr4(read_cr4() | X86_CR4_OSFXSR | X86_CR4_OSXMMEXCPT);
 }
 
 /* External declarations */

--- a/include/lib.h
+++ b/include/lib.h
@@ -277,9 +277,10 @@ static inline unsigned long read_cr8(void) {
     return cr8;
 }
 
-static inline void write_sp(void *sp) {
-    asm volatile("mov %0, %%" STR(_ASM_SP)::"r"(sp) : "memory");
-}
+#define WRITE_SP(sp)                                                                     \
+    do {                                                                                 \
+        asm volatile("mov %0, %%" STR(_ASM_SP)::"r"((sp)) : "memory");                   \
+    } while (0)
 
 static inline void lgdt(const gdt_ptr_t *gdt_ptr) {
     asm volatile("lgdt %0" ::"m"(*gdt_ptr));

--- a/include/percpu.h
+++ b/include/percpu.h
@@ -125,5 +125,6 @@ typedef struct percpu percpu_t;
 
 extern void init_percpu(void);
 extern percpu_t *get_percpu_page(unsigned int cpu);
+extern void for_each_percpu(void (*func)(percpu_t *percpu));
 
 #endif /* KTF_PERCPU_H */

--- a/smp/smp.c
+++ b/smp/smp.c
@@ -42,12 +42,13 @@ extern void ap_start(void);
 
 static unsigned nr_cpus;
 
-static unsigned ap_cpuid;
-static bool ap_callin;
+static __data_init unsigned ap_cpuid;
+static __data_init bool ap_callin;
+static __data_init void *ap_new_sp;
 cr3_t __data_init ap_cr3;
 
 void __noreturn __naked ap_startup(void) {
-    write_sp(get_free_pages_top(PAGE_ORDER_2M, GFP_KERNEL));
+    WRITE_SP(ap_new_sp);
 
     init_traps(ap_cpuid);
     init_apic(ap_cpuid, apic_get_mode());
@@ -69,6 +70,7 @@ static __text_init void boot_cpu(percpu_t *percpu) {
     if (percpu->bsp)
         return;
 
+    ap_new_sp = get_free_pages_top(PAGE_ORDER_2M, GFP_KERNEL);
     ap_cpuid = percpu->cpu_id;
     ap_callin = false;
     smp_wmb();

--- a/smp/smp.c
+++ b/smp/smp.c
@@ -46,7 +46,7 @@ static unsigned ap_cpuid;
 static bool ap_callin;
 cr3_t __data_init ap_cr3;
 
-void __noreturn ap_startup(void) {
+void __noreturn __naked ap_startup(void) {
     write_sp(get_free_pages_top(PAGE_ORDER_2M, GFP_KERNEL));
 
     init_traps(ap_cpuid);

--- a/tests/test.c
+++ b/tests/test.c
@@ -63,16 +63,12 @@ static void cpu_freq_expect(const char *cpu_str, uint64_t expectation) {
     printk("Got CPU string '%s' and frequency '%llu'\n", cpu_str, result);
     return;
 }
-#endif
 
 static int __user_text func(void *arg) { return 0; }
 
-void test_main(void) {
-    printk("\nTest:\n");
-
+static int ktf_unit_tests(void) {
     usermode_call(func, NULL);
 
-#ifdef KTF_UNIT_TEST
     printk("\nLet the UNITTESTs begin\n");
     printk("Commandline parsing: %s\n", kernel_cmdline);
 
@@ -139,7 +135,17 @@ void test_main(void) {
     cpu_freq_expect("AMD Ryzen Threadripper 1950X 16-Core Processor", 0);
     cpu_freq_expect("Prototyp Amazing Foo One @ 1GHz", 1000000000);
     cpu_freq_expect("Prototyp Amazing Foo Two @ 1.00GHz", 1000000000);
+
+    return 0;
+}
+#else
+static int ktf_unit_tests(void) { return 0; }
 #endif
+
+void test_main(void) {
+    printk("\nTest:\n");
+
+    ktf_unit_tests();
 
     wait_for_all_tasks();
 


### PR DESCRIPTION
*Issue #167 , if available:*
Fixes #167 

*Description of changes:*
This PR depends on #170.

Disablement of CET protection (to avoid `endbr64` instruction), omit frame pointer compile flag as well as naked function
attribute are merely a cleanup improvements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
