### PR TITLE
cmdline: set start/end cmdline addresses

### DIFF
--- a/common/setup.c
+++ b/common/setup.c
@@ -115,7 +115,7 @@ void __text_init cmdline_parse(const char *cmdline) {
             /* assume a bool later */
             optval = opt;
 
-        for (param = __start_cmdline; param < __end_cmdline; param++) {
+        for (param = &__start_cmdline; param < &__end_cmdline; param++) {
             if (strcmp(param->name, optkey))
                 continue;
 

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -53,7 +53,7 @@ extern unsigned long __start_bss_init[], __end_bss_init[];
 
 extern unsigned long __start_rmode[], __end_rmode[];
 
-extern struct ktf_param *__start_cmdline, *__end_cmdline;
+extern struct ktf_param __start_cmdline, __end_cmdline;
 
 extern unsigned long __weak __start_symbols[], __end_symbols[];
 


### PR DESCRIPTION
Fix getting the addresses of __start_cmdline and __end_cmdline as being
set by the linker.

Signed-off-by: Daniele Ahmed <ahmeddan amazon c;0m >

*Issue #, if available:*

*Description of changes:* the command line was not working correctly and __start_cmdline (some address) and __end_cmdline (always 0) were not being set correctly. Now the command line arguments are being read correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
