### PR TITLE
ioapic: no id sanity check

### DIFF
--- a/arch/x86/ioapic.c
+++ b/arch/x86/ioapic.c
@@ -177,10 +177,11 @@ void __text_init init_ioapic(void) {
 
         id.reg = ioapic_read32(ioapic, IOAPIC_ID);
         if (ioapic->id != id.apic_id) {
-            panic("IOAPIC with unexpected APIC ID detected: 0x%02x (expected: "
-                  "0x%02x)\n",
-                  id.apic_id, ioapic->id);
+            printk("IOAPIC with unexpected APIC ID detected: 0x%02x (expected: "
+                   "0x%02x)\n",
+                   id.apic_id, ioapic->id);
         }
+        ioapic->id = id.apic_id;
 
         version.reg = ioapic_read32(ioapic, IOAPIC_VERSION);
         ioapic->version = version.version;


### PR DESCRIPTION
*Issue #, if available:* #175

*Description of changes:*

Remove the double check on a device's IOAPIC ID as it breaks
on systems where the ID returned by a device differs from
the one read at boot from the MADT tables

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
