### PR TITLE
string: avoid panic strtok on null input

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -288,10 +288,13 @@ static inline size_t strcspn(const char *s1, const char *s2) {
 
 static inline char *strtok(char *s, const char *delim) {
 
-    static char *lasts;
+    static char *lasts = NULL;
     int ch;
 
-    if (NULL == s)
+    if (s == NULL && lasts == NULL)
+        return NULL;
+
+    if (s == NULL)
         s = lasts + 1;
 
     do {


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

The behavior of strtok when given a NULL input on the first call
is to panic on an unmapped virtual address. This commit changes it
by returning NULL instead of panic.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
