### PR TITLE
smp: map MP tables memory range (512KB - 1KB, 512KB)

### DIFF
--- a/smp/mptables.c
+++ b/smp/mptables.c
@@ -85,8 +85,8 @@ static mpf_t *get_mpf_addr(void) {
     if (ptr)
         return ptr;
 
-    sysm_addr = paddr_to_virt_kern(get_memory_range_end(KB(512)));
-    ptr = find_mpf(sysm_addr - KB(1), sysm_addr);
+    sysm_addr = kmap_4k(paddr_to_mfn(get_memory_range_end(KB(512)) - KB(1)), L1_PROT_RO);
+    ptr = find_mpf(sysm_addr, sysm_addr + KB(1));
     if (ptr)
         return ptr;
 


### PR DESCRIPTION
Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

Fixes: #184 (missing mapping)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
