### PR TITLE
Add support for task groups; simplify task_func_t

### DIFF
--- a/common/sched.c
+++ b/common/sched.c
@@ -203,7 +203,7 @@ static void run_task(task_t *task) {
     printk("CPU[%u]: Running task %s[%u]\n", task->cpu, task->name, task->id);
 
     set_task_state(task, TASK_STATE_RUNNING);
-    task->func(task, task->arg);
+    task->func(task->arg);
     set_task_state(task, TASK_STATE_DONE);
 }
 

--- a/common/sched.c
+++ b/common/sched.c
@@ -87,6 +87,7 @@ static task_t *create_task(void) {
 
     memset(task, 0, sizeof(*task));
     task->id = next_tid++;
+    task->gid = TASK_GROUP_UNSPECIFIED;
     task->cpu = INVALID_CPU;
     set_task_state(task, TASK_STATE_NEW);
 
@@ -207,7 +208,7 @@ static void run_task(task_t *task) {
     set_task_state(task, TASK_STATE_DONE);
 }
 
-void wait_for_all_tasks(void) {
+void wait_for_task_group(task_group_t group) {
     task_t *task;
     bool busy;
 
@@ -215,6 +216,10 @@ void wait_for_all_tasks(void) {
         busy = false;
 
         list_for_each_entry (task, &tasks, list) {
+            /* When group is unspecified the functions waits for all tasks. */
+            if (group != TASK_GROUP_UNSPECIFIED && task->gid != group)
+                continue;
+
             if (get_task_state(task) != TASK_STATE_DONE) {
                 busy = true;
                 wait_for_task_state(task, TASK_STATE_DONE);

--- a/include/sched.h
+++ b/include/sched.h
@@ -41,12 +41,19 @@ enum task_state {
 };
 typedef enum task_state task_state_t;
 
+enum task_group {
+    TASK_GROUP_UNSPECIFIED = 0,
+    TASK_GROUP_TEST,
+};
+typedef enum task_group task_group_t;
+
 typedef unsigned int tid_t;
 
 struct task {
     list_head_t list;
 
     tid_t id;
+    task_group_t gid;
     task_state_t state;
 
     unsigned int cpu;
@@ -68,6 +75,14 @@ extern task_t *get_task_for_cpu(unsigned int cpu);
 extern task_t *new_task(const char *name, task_func_t func, void *arg);
 extern void schedule_task(task_t *task, unsigned int cpu);
 extern void run_tasks(unsigned int cpu);
-extern void wait_for_all_tasks(void);
+extern void wait_for_task_group(task_group_t group);
+
+/* Static declarations */
+
+static inline void set_task_group(task_t *task, task_group_t gid) { task->gid = gid; }
+
+static inline void wait_for_all_tasks(void) {
+    wait_for_task_group(TASK_GROUP_UNSPECIFIED);
+}
 
 #endif /* KTF_SCHED_H */

--- a/include/sched.h
+++ b/include/sched.h
@@ -30,7 +30,7 @@
 #include <list.h>
 #include <page.h>
 
-typedef void (*task_func_t)(void *this, void *arg);
+typedef void (*task_func_t)(void *arg);
 
 enum task_state {
     TASK_STATE_NEW,


### PR DESCRIPTION
```
sched: remove 'this' parameter from task_func_t

The task function does not typically need access to the task struction.
Having this parameter complicates argument lists for tasks.
```
```
sched: add task group functionality

Add task_group_t identifier to the task structure, allowing to assign
given task to a specific supported group. This allows to easily select
specified tasks from a list of all tasks and simplifies waiting for their
completion.
By default all tasks are created with TASK_GROUP_UNSPECIFIED.
The task group get be assigned with set_task_group().
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
