### PR TITLE
pmm, regions: separate memory regions related code from PMM

### DIFF
--- a/arch/x86/boot/multiboot.c
+++ b/arch/x86/boot/multiboot.c
@@ -23,9 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include <console.h>
-#include <ktf.h>
 #include <multiboot.h>
-#include <string.h>
 
 static multiboot_info_t *multiboot_info;
 

--- a/common/setup.c
+++ b/common/setup.c
@@ -43,6 +43,7 @@
 #include <traps.h>
 
 #include <mm/pmm.h>
+#include <mm/regions.h>
 #include <mm/slab.h>
 #include <mm/vmm.h>
 #include <smp/mptables.h>
@@ -228,6 +229,7 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     cmdline_parse(kernel_cmdline);
 
     /* Initialize Physical Memory Manager */
+    init_regions();
     init_pmm();
 
     /* Setup final pagetables */

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -25,56 +25,10 @@
 #ifndef KTF_PMM_H
 #define KTF_PMM_H
 
-#define BDA_ADDR_START 0x400
-#define BDA_ADDR_END   0x4FF
-
-#define BDA_COM_PORTS_ENTRY 0x400
-#define EBDA_ADDR_ENTRY     0x40E
-
-#define BIOS_ACPI_ROM_START 0xE0000
-#define BIOS_ACPI_ROM_STOP  0xFFFFF
-
-#define BIOS_ROM_ADDR_START 0xF0000
-
 #ifndef __ASSEMBLY__
-#include <cmdline.h>
 #include <list.h>
-#include <page.h>
 
-extern unsigned long __start_text[], __end_text[];
-extern unsigned long __start_data[], __end_data[];
-extern unsigned long __start_bss[], __end_bss[];
-extern unsigned long __start_rodata[], __end_rodata[];
-
-extern unsigned long __start_text_user[], __end_text_user[];
-extern unsigned long __start_data_user[], __end_data_user[];
-extern unsigned long __start_bss_user[], __end_bss_user[];
-
-extern unsigned long __start_text_init[], __end_text_init[];
-extern unsigned long __start_data_init[], __end_data_init[];
-extern unsigned long __start_bss_init[], __end_bss_init[];
-
-extern unsigned long __start_text_rmode[], __end_text_rmode[];
-extern unsigned long __start_data_rmode[], __end_data_rmode[];
-extern unsigned long __start_bss_rmode[], __end_bss_rmode[];
-
-extern struct ktf_param __start_cmdline[], __end_cmdline[];
-
-extern unsigned long __weak __start_symbols[], __end_symbols[];
-
-struct addr_range {
-    const char *name;
-    unsigned long base;
-    unsigned long flags;
-    void *start;
-    void *end;
-};
-typedef struct addr_range addr_range_t;
-
-extern addr_range_t addr_ranges[];
-#define for_each_memory_range(ptr)                                                       \
-    for (addr_range_t *ptr = &addr_ranges[0];                                            \
-         ptr->name != NULL || (ptr->start != 0x0 && ptr->end != 0x0); ptr++)
+#include <mm/regions.h>
 
 struct frame {
     struct list_head list;
@@ -90,15 +44,7 @@ typedef bool (*free_frames_cond_t)(frame_t *free_frame);
 
 /* External definitions */
 
-extern void display_memory_map(void);
 extern void display_frames_count(void);
-
-extern addr_range_t get_memory_range(paddr_t pa);
-extern paddr_t get_memory_range_start(paddr_t pa);
-extern paddr_t get_memory_range_end(paddr_t pa);
-
-extern bool paddr_invalid(paddr_t pa);
-
 extern void init_pmm(void);
 
 extern frame_t *get_free_frames_cond(free_frames_cond_t cb);
@@ -110,37 +56,13 @@ extern void map_used_memory(void);
 
 /* Static definitions */
 
+static inline bool paddr_invalid(paddr_t pa) {
+    return pa == PADDR_INVALID || !has_memory_range(pa);
+}
+
 static inline bool mfn_invalid(mfn_t mfn) { return paddr_invalid(mfn_to_paddr(mfn)); }
 
 static inline mfn_t get_free_frame(void) { return get_free_frames(PAGE_ORDER_4K); }
-
-static inline bool in_text_section(const void *addr) {
-    return (addr >= _ptr(__start_text) && addr < _ptr(__end_text)) ||
-           (addr >= _ptr(__start_text_init) && addr < _ptr(__end_text_init));
-}
-
-static inline bool in_init_section(const void *addr) {
-    return (addr >= _ptr(__start_text_init) && addr < _ptr(__end_text_init)) ||
-           (addr >= _ptr(__start_data_init) && addr < _ptr(__end_data_init)) ||
-           (addr >= _ptr(__start_bss_init) && addr < _ptr(__end_bss_init));
-}
-
-static inline bool in_user_section(const void *addr) {
-    return (addr >= _ptr(__start_text_user) && addr < _ptr(__end_text_user)) ||
-           (addr >= _ptr(__start_data_user) && addr < _ptr(__end_data_user)) ||
-           (addr >= _ptr(__start_bss_user) && addr < _ptr(__end_bss_user));
-}
-
-static inline bool in_kernel_section(const void *addr) {
-    return (addr >= _ptr(__start_text) && addr < _ptr(__end_text)) ||
-           (addr >= _ptr(__start_data) && addr < _ptr(__end_data)) ||
-           (addr >= _ptr(__start_bss) && addr < _ptr(__end_bss)) ||
-           (addr >= _ptr(__start_rodata) && addr < _ptr(__end_rodata));
-}
-
-static inline uint32_t get_bios_ebda_addr(void) {
-    return (*(uint16_t *) paddr_to_virt_kern(EBDA_ADDR_ENTRY)) << 4;
-}
 
 #endif /* __ASSEMBLY__ */
 

--- a/include/mm/regions.h
+++ b/include/mm/regions.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2021 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef KTF_REGIONS_H
+#define KTF_REGIONS_H
+
+#define BDA_ADDR_START 0x400
+#define BDA_ADDR_END   0x4FF
+
+#define BDA_COM_PORTS_ENTRY 0x400
+#define EBDA_ADDR_ENTRY     0x40E
+
+#define BIOS_ACPI_ROM_START 0xE0000
+#define BIOS_ACPI_ROM_STOP  0xFFFFF
+
+#define BIOS_ROM_ADDR_START 0xF0000
+
+#ifndef __ASSEMBLY__
+#include <cmdline.h>
+#include <page.h>
+#include <string.h>
+
+extern unsigned long __start_text[], __end_text[];
+extern unsigned long __start_data[], __end_data[];
+extern unsigned long __start_bss[], __end_bss[];
+extern unsigned long __start_rodata[], __end_rodata[];
+
+extern unsigned long __start_text_user[], __end_text_user[];
+extern unsigned long __start_data_user[], __end_data_user[];
+extern unsigned long __start_bss_user[], __end_bss_user[];
+
+extern unsigned long __start_text_init[], __end_text_init[];
+extern unsigned long __start_data_init[], __end_data_init[];
+extern unsigned long __start_bss_init[], __end_bss_init[];
+
+extern unsigned long __start_text_rmode[], __end_text_rmode[];
+extern unsigned long __start_data_rmode[], __end_data_rmode[];
+extern unsigned long __start_bss_rmode[], __end_bss_rmode[];
+
+extern struct ktf_param __start_cmdline[], __end_cmdline[];
+
+extern unsigned long __weak __start_symbols[], __end_symbols[];
+
+struct addr_range {
+    const char *name;
+    unsigned long base;
+    unsigned long flags;
+    void *start;
+    void *end;
+};
+typedef struct addr_range addr_range_t;
+
+extern addr_range_t addr_ranges[];
+#define for_each_memory_range(ptr)                                                       \
+    for (addr_range_t *ptr = &addr_ranges[0];                                            \
+         ptr->name != NULL || (ptr->start != 0x0 && ptr->end != 0x0); ptr++)
+
+extern unsigned regions_num;
+
+/* External definitions */
+
+extern void display_memory_map(void);
+
+extern addr_range_t get_memory_range(paddr_t pa);
+extern paddr_t get_memory_range_start(paddr_t pa);
+extern paddr_t get_memory_range_end(paddr_t pa);
+
+extern int get_avail_memory_range(unsigned index, addr_range_t *r);
+extern bool has_memory_range(paddr_t pa);
+
+extern void init_regions(void);
+
+/* Static definitions */
+
+static inline bool in_text_section(const void *addr) {
+    return (addr >= _ptr(__start_text) && addr < _ptr(__end_text)) ||
+           (addr >= _ptr(__start_text_init) && addr < _ptr(__end_text_init));
+}
+
+static inline bool in_init_section(const void *addr) {
+    return (addr >= _ptr(__start_text_init) && addr < _ptr(__end_text_init)) ||
+           (addr >= _ptr(__start_data_init) && addr < _ptr(__end_data_init)) ||
+           (addr >= _ptr(__start_bss_init) && addr < _ptr(__end_bss_init));
+}
+
+static inline bool in_user_section(const void *addr) {
+    return (addr >= _ptr(__start_text_user) && addr < _ptr(__end_text_user)) ||
+           (addr >= _ptr(__start_data_user) && addr < _ptr(__end_data_user)) ||
+           (addr >= _ptr(__start_bss_user) && addr < _ptr(__end_bss_user));
+}
+
+static inline bool in_kernel_section(const void *addr) {
+    return (addr >= _ptr(__start_text) && addr < _ptr(__end_text)) ||
+           (addr >= _ptr(__start_data) && addr < _ptr(__end_data)) ||
+           (addr >= _ptr(__start_bss) && addr < _ptr(__end_bss)) ||
+           (addr >= _ptr(__start_rodata) && addr < _ptr(__end_rodata));
+}
+
+static inline uint32_t get_bios_ebda_addr(void) {
+    return (*(uint16_t *) paddr_to_virt_kern(EBDA_ADDR_ENTRY)) << 4;
+}
+
+#endif /* __ASSEMBLY__ */
+
+#endif /* KTF_REGIONS_H */

--- a/include/multiboot.h
+++ b/include/multiboot.h
@@ -290,8 +290,7 @@ struct multiboot_apm_info {
 extern void display_multiboot_mmap(void);
 extern void init_multiboot(multiboot_info_t *mbi, const char **cmdline);
 
-#include <mm/pmm.h>
-#include <page.h>
+#include <mm/regions.h>
 extern void map_multiboot_areas(void);
 extern unsigned mbi_get_avail_memory_ranges_num(void);
 extern int mbi_get_avail_memory_range(unsigned index, addr_range_t *r);

--- a/mm/regions.c
+++ b/mm/regions.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <console.h>
+#include <multiboot.h>
+
+#include <mm/regions.h>
+
+unsigned regions_num;
+
+#define _RANGE(_name, _base, _flags, _start, _end)                                       \
+    {                                                                                    \
+        .name = _name, .base = (_base), .flags = (_flags), .start = _ptr(_start),        \
+        .end = _ptr(_end)                                                                \
+    }
+
+#define IDENT_RANGE(name, flags, start, end)                                             \
+    _RANGE(name, VIRT_IDENT_BASE, flags, start, end)
+
+#define USER_RANGE(name, flags, start, end)                                              \
+    _RANGE(name, VIRT_USER_BASE, flags, start, end)
+
+#define KERNEL_RANGE(name, flags, start, end)                                            \
+    _RANGE(name, VIRT_KERNEL_BASE, flags, start, end)
+
+addr_range_t addr_ranges[] = {
+    /* clang-format off */
+    IDENT_RANGE( ".text.init",  L1_PROT_RO,      __start_text_init,     __end_text_init ),
+    IDENT_RANGE( ".data.init",  L1_PROT,         __start_data_init,     __end_data_init ),
+    IDENT_RANGE( ".bss.init",   L1_PROT,         __start_bss_init,      __end_bss_init  ),
+
+    IDENT_RANGE( ".text.rmode", L1_PROT_RO,      __start_text_rmode,    __end_text_rmode),
+    IDENT_RANGE( ".data.rmode", L1_PROT,         __start_data_rmode,    __end_data_rmode),
+    IDENT_RANGE( ".bss.rmode",  L1_PROT,         __start_bss_rmode,     __end_bss_rmode ),
+
+    USER_RANGE( ".text.user",   L1_PROT_USER_RO, __start_text_user,     __end_text_user ),
+    USER_RANGE( ".data.user",   L1_PROT_USER,    __start_data_user,     __end_data_user ),
+    USER_RANGE( ".bss.user",    L1_PROT_USER,    __start_bss_user,      __end_bss_user  ),
+
+    KERNEL_RANGE( ".text",      L1_PROT_RO,      __start_text,           __end_text      ),
+    KERNEL_RANGE( ".data",      L1_PROT,         __start_data,           __end_data      ),
+    KERNEL_RANGE( ".bss",       L1_PROT,         __start_bss,            __end_bss       ),
+    KERNEL_RANGE( ".rodata",    L1_PROT_RO,      __start_rodata,         __end_rodata    ),
+    KERNEL_RANGE( ".symbols",   L1_PROT_RO,      __start_symbols,        __end_symbols   ),
+    /* clang-format on */
+
+    {0x0} /* NULL array terminator */
+};
+
+void display_memory_map(void) {
+    printk("Memory Map:\n");
+
+    for_each_memory_range (r) {
+        printk("%11s: VA: [0x%016lx - 0x%016lx] PA: [0x%08lx - 0x%08lx]\n", r->name,
+               _ul(r->start), _ul(r->end), _ul(r->start - r->base),
+               _ul(r->end - r->base));
+    }
+}
+
+addr_range_t get_memory_range(paddr_t pa) {
+    addr_range_t r;
+
+    memset(&r, 0, sizeof(r));
+    if (mbi_get_memory_range(pa, &r) < 0)
+        /* FIXME: e820_lower_memory_bound() */
+        panic("Unable to get memory range for: 0x%016lx\n", pa);
+
+    return r;
+}
+
+paddr_t get_memory_range_start(paddr_t pa) {
+    addr_range_t r = get_memory_range(pa);
+
+    return _paddr(r.start);
+}
+
+paddr_t get_memory_range_end(paddr_t pa) {
+    addr_range_t r = get_memory_range(pa);
+
+    return _paddr(r.end);
+}
+
+int get_avail_memory_range(unsigned index, addr_range_t *r) {
+    return mbi_get_avail_memory_range(index, r);
+}
+
+bool has_memory_range(paddr_t pa) { return mbi_get_memory_range(pa, NULL) == 0; }
+
+void init_regions(void) { regions_num = mbi_get_avail_memory_ranges_num(); }


### PR DESCRIPTION
Add regions.{c,h} files to keep memory regions handling code separated
from PMM functionality. This allows to maintain code better and
isolate PMM from multiboot dependency.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
