### PR TITLE
drivers/kbd: fix initialization flush loop

### DIFF
--- a/drivers/keyboard.c
+++ b/drivers/keyboard.c
@@ -69,7 +69,7 @@ void init_keyboard(uint8_t dst_cpus) {
     outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_DISABLE_PORT_2);
 
     /* Flush output buffer */
-    while (inb(KEYBOARD_PORT_DATA) & KEYBOARD_STATUS_OUT_FULL)
+    while (inb(KEYBOARD_PORT_CMD) & KEYBOARD_STATUS_OUT_FULL)
         ; /* discard leftover bytes */
 
     /* Controller configuration */


### PR DESCRIPTION
Use Status Register port instead of Data port.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@amazon.de>

Partially addresses: #146 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
