### PR TITLE
ACPICA: Implement OS Layer for ACPICA integration

### DIFF
--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -93,6 +93,9 @@ END_FUNC(handle_exception)
 interrupt_handler timer timer_interrupt_handler
 interrupt_handler uart uart_interrupt_handler
 interrupt_handler keyboard keyboard_interrupt_handler
+#ifdef KTF_ACPICA
+interrupt_handler acpi acpi_interrupt_handler
+#endif
 
 ENTRY(usermode_call_asm)
     /* FIXME: Add 32-bit support */

--- a/common/console.c
+++ b/common/console.c
@@ -70,6 +70,18 @@ void printk(const char *fmt, ...) {
     va_end(args);
 }
 
+#ifdef KTF_ACPICA
+void AcpiOsVprintf(const char *Format, va_list args) { vprintk(Format, args); }
+
+void AcpiOsPrintf(const char *Format, ...) {
+    va_list args;
+
+    va_start(args, Format);
+    vprintk(Format, args);
+    va_end(args);
+}
+#endif
+
 void putchar(int c) { putc(SERIAL_CONSOLE, c); }
 
 void serial_console_write(const char *buf, size_t len) {

--- a/drivers/acpi/acpica/osl.c
+++ b/drivers/acpi/acpica/osl.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifdef KTF_ACPICA
+#include <ktf.h>
+
+#include "acpi.h"
+
+/* General OS functions */
+
+ACPI_STATUS AcpiOsInitialize(void) {
+    dprintk("ACPI OS Initialization:\n");
+
+    return AE_OK;
+}
+
+ACPI_STATUS AcpiOsTerminate(void) {
+    dprintk("ACPI OS Termination:\n");
+
+    return AE_OK;
+}
+
+ACPI_STATUS AcpiOsSignal(UINT32 Function, void *Info) {
+    switch (Function) {
+    case ACPI_SIGNAL_FATAL: {
+        ACPI_SIGNAL_FATAL_INFO *info = Info;
+
+        panic("ACPI: Received ACPI_SIGNAL_FATAL: Type: %u, Code: %u, Arg: %u",
+              info ? info->Type : 0, info ? info->Code : 0, info ? info->Argument : 0);
+    } break;
+    case ACPI_SIGNAL_BREAKPOINT: {
+        char *bp_msg = Info;
+
+        printk("ACPI: Received ACPI_SIGNAL_BREAKPOINT: %s", bp_msg ?: "");
+    } break;
+    default:
+        BUG();
+    }
+
+    return AE_OK;
+}
+
+ACPI_STATUS AcpiOsEnterSleep(UINT8 SleepState, UINT32 RegaValue, UINT32 RegbValue) {
+    dprintk("ACPI Entering sleep state S%u.\n", SleepState);
+
+    return AE_OK;
+}
+#endif /* KTF_ACPICA */

--- a/drivers/acpi/acpica/osl.c
+++ b/drivers/acpi/acpica/osl.c
@@ -25,6 +25,7 @@
 #ifdef KTF_ACPICA
 #include <ktf.h>
 #include <mm/slab.h>
+#include <time.h>
 
 #include "acpi.h"
 
@@ -154,6 +155,45 @@ ACPI_STATUS AcpiOsWritePort(ACPI_IO_ADDRESS Address, UINT32 Value, UINT32 Width)
     return AE_OK;
 }
 
+/* General Table handling functions */
+
+ACPI_PHYSICAL_ADDRESS AcpiOsGetRootPointer(void) {
+    ACPI_PHYSICAL_ADDRESS pa = 0;
+
+    AcpiFindRootPointer(&pa);
+    return pa;
+}
+
+ACPI_STATUS AcpiOsPredefinedOverride(const ACPI_PREDEFINED_NAMES *PredefinedObject,
+                                     ACPI_STRING *NewValue) {
+    if (!NewValue)
+        return AE_BAD_PARAMETER;
+
+    *NewValue = NULL;
+    return AE_OK;
+}
+
+ACPI_STATUS AcpiOsTableOverride(ACPI_TABLE_HEADER *ExistingTable,
+                                ACPI_TABLE_HEADER **NewTable) {
+    if (!NewTable)
+        return AE_BAD_PARAMETER;
+
+    *NewTable = NULL;
+    return AE_OK;
+}
+
+ACPI_STATUS AcpiOsPhysicalTableOverride(ACPI_TABLE_HEADER *ExistingTable,
+                                        ACPI_PHYSICAL_ADDRESS *NewAddress,
+                                        UINT32 *NewTableLength) {
+    if (!NewAddress || !NewTableLength)
+        return AE_BAD_PARAMETER;
+
+    *NewAddress = _paddr(NULL);
+    *NewTableLength = 0;
+
+    return AE_OK;
+}
+
 /* Memory management functions */
 
 void *AcpiOsAllocate(ACPI_SIZE Size) { return kmalloc(Size); }
@@ -192,4 +232,14 @@ void AcpiOsUnmapMemory(void *LogicalAddress, ACPI_SIZE Length) {
     for (unsigned i = 0; i < num_pages; i++, mfn++)
         kunmap(mfn_to_virt_kern(mfn), PAGE_ORDER_4K);
 }
+
+/* Time management functions */
+
+void AcpiOsSleep(UINT64 Miliseconds) { msleep(Miliseconds); }
+
+/* FIXME: Return in correct 100ns units */
+UINT64 AcpiOsGetTimer(void) { return get_timer_ticks(); }
+
+/* FIXME: Use microseconds granularity */
+void AcpiOsStall(UINT32 Microseconds) { msleep(1); }
 #endif /* KTF_ACPICA */

--- a/include/sched.h
+++ b/include/sched.h
@@ -43,6 +43,7 @@ typedef enum task_state task_state_t;
 
 enum task_group {
     TASK_GROUP_UNSPECIFIED = 0,
+    TASK_GROUP_ACPI,
     TASK_GROUP_TEST,
 };
 typedef enum task_group task_group_t;


### PR DESCRIPTION
The ACPICA OSL code is guarded with KTF_ACPICA compilation flag, which is inactive by default.

*Partially implements issue #87 *

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
