### PR TITLE
Exception table support

### DIFF
--- a/arch/x86/extables.c
+++ b/arch/x86/extables.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+void init_extables(void) { /* no-op */
+}

--- a/arch/x86/link.ld
+++ b/arch/x86/link.ld
@@ -170,6 +170,14 @@ SECTIONS
         __end_data = .;
     } :kernel
 
+    .extables BLOCK(4K) : ALIGN(4K)
+    {
+        __start_extables = .;
+            *(.extables)
+        . = ALIGN(4K);
+        __end_extables = .;
+    } :kernel
+
     .bss BLOCK(4K) : ALIGN(4K)
     {
         . = ALIGN(4K);

--- a/common/setup.c
+++ b/common/setup.c
@@ -254,11 +254,11 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     if (opt_debug)
         dump_pagetables();
 
-    /* TODO: Exception tables */
-
     init_percpu();
 
     init_traps(get_bsp_cpu_id());
+
+    init_extables();
 
     init_slab();
 

--- a/include/arch/x86/asm-macros.h
+++ b/include/arch/x86/asm-macros.h
@@ -47,6 +47,9 @@
 
 #define PT_PADDR(table, shift) (((.- (table)) / PTE_SIZE) << (shift))
 
+#define PUSHSECTION(name) ".pushsection " STR(name) " ;\n"
+#define POPSECTION        ".popsection;\n"
+
 #ifdef __ASSEMBLY__
 
 /* clang-format off */

--- a/include/extables.h
+++ b/include/extables.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef KTF_EXTABLES_H
+#define KTF_EXTABLES_H
+
+#include <arch/x86/processor.h>
+
+typedef void (*extable_entry_callback_t)(cpu_regs_t *regs);
+
+struct extable_entry {
+    x86_reg_t fault_addr;
+    x86_reg_t fixup;
+    extable_entry_callback_t cb;
+} __packed;
+typedef struct extable_entry extable_entry_t;
+
+#if defined(__x86_64__)
+#define ASM_EXTABLE_HANDLER(fault_address, fixup, handler)                               \
+    PUSHSECTION(.extables)                                                               \
+    ".quad " STR(fault_address) ", " STR(fixup) ", " STR(handler) ";\n" POPSECTION
+#else
+#define ASM_EXTABLE_HANDLER(fault_address, fixup, handler)                               \
+    PUSHSECTION(.extables)                                                               \
+    ".long " STR(fault_address) ", " STR(fixup) ", " STR(handler) ";\n" POPSECTION
+#endif
+
+#define ASM_EXTABLE(fault_address, fixup) ASM_EXTABLE_HANDLER(fault_address, fixup, 0)
+
+extern void init_extables(void);
+
+#endif

--- a/include/lib.h
+++ b/include/lib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ * Copyright © 2021 Amazon.com, Inc. or its affiliates.
  * All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/include/lib.h
+++ b/include/lib.h
@@ -434,4 +434,7 @@ extern void srand(unsigned s);
 
 extern int rand(void);
 
+extern bool wrmsr_safe(uint32_t msr_idx, uint64_t value);
+extern bool rdmsr_safe(uint32_t msr_idx, uint64_t *value);
+
 #endif /* KTF_LIB_H */

--- a/include/mm/regions.h
+++ b/include/mm/regions.h
@@ -38,6 +38,7 @@
 
 #ifndef __ASSEMBLY__
 #include <cmdline.h>
+#include <extables.h>
 #include <page.h>
 #include <string.h>
 
@@ -56,6 +57,7 @@ extern unsigned long __start_bss_init[], __end_bss_init[];
 
 extern unsigned long __start_text_rmode[], __end_text_rmode[];
 extern unsigned long __start_data_rmode[], __end_data_rmode[];
+extern struct extable_entry __start_extables[], __end_extables[];
 extern unsigned long __start_bss_rmode[], __end_bss_rmode[];
 
 extern struct ktf_param __start_cmdline[], __end_cmdline[];

--- a/mm/regions.c
+++ b/mm/regions.c
@@ -60,6 +60,7 @@ addr_range_t addr_ranges[] = {
 
     KERNEL_RANGE( ".text",      L1_PROT_RO,      __start_text,           __end_text      ),
     KERNEL_RANGE( ".data",      L1_PROT,         __start_data,           __end_data      ),
+    KERNEL_RANGE( ".extables",  L1_PROT_RO,      __start_extables,       __end_extables  ),
     KERNEL_RANGE( ".bss",       L1_PROT,         __start_bss,            __end_bss       ),
     KERNEL_RANGE( ".rodata",    L1_PROT_RO,      __start_rodata,         __end_rodata    ),
     KERNEL_RANGE( ".symbols",   L1_PROT_RO,      __start_symbols,        __end_symbols   ),


### PR DESCRIPTION
*Issue #, if available:* #6

*Description of changes:*

This PR adds support for exception tables and uses them to implement rdmsr_safe and wrmsr_safe, that will fail by reporting the error in a boolean variable if the operation on an msr can't be completed due to an exception.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
