### PR TITLE
Extables

### DIFF
--- a/arch/x86/extables.c
+++ b/arch/x86/extables.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2021 Open Source Security, Inc.
  * All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,5 +24,12 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-void init_extables(void) { /* no-op */
+#include <mm/regions.h>
+
+void init_extables(void) {
+    for (extable_entry_t *cur = __start_extables; cur < __stop_extables; ++cur) {
+        if (!cur->fixup && !cur->cb)
+            panic("extable entry #%d for addr 0x%lx lacks fixup and callback!\n",
+                  cur - __start_extables, cur->fault_addr);
+    }
 }

--- a/arch/x86/link.ld
+++ b/arch/x86/link.ld
@@ -176,6 +176,7 @@ SECTIONS
     {
         __start_extables = .;
             *(.extables)
+        __stop_extables = .;
         . = ALIGN(4K);
         __end_extables = .;
     } :kernel

--- a/arch/x86/traps.c
+++ b/arch/x86/traps.c
@@ -290,7 +290,7 @@ void print_callstack(const void *sp, const void *ip) {
 }
 
 static bool extables_fixup(struct cpu_regs *regs) {
-    for (extable_entry_t *cur = __start_extables; cur < __end_extables; ++cur) {
+    for (extable_entry_t *cur = __start_extables; cur < __stop_extables; ++cur) {
         if (regs->_ASM_IP != cur->fault_addr)
             continue;
 

--- a/include/arch/x86/processor.h
+++ b/include/arch/x86/processor.h
@@ -173,6 +173,9 @@
 #define X86_EX_SEL_TLB_IDT2 0x11
 
 #ifndef __ASSEMBLY__
+#include <stdbool.h>
+#include <stdint.h>
+
 union x86_ex_error_code {
     uint32_t error_code;
     struct __packed {

--- a/include/cmdline.h
+++ b/include/cmdline.h
@@ -26,6 +26,7 @@
 #define KTF_CMDLINE_H
 
 #ifndef __ASSEMBLY__
+#include <compiler.h>
 
 #define PARAM_MAX_LENGTH 32
 

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -49,6 +49,8 @@
 #define GHZ(x) (MHZ(x) * 1000)
 
 #ifndef __ASSEMBLY__
+#include <inttypes.h>
+
 typedef uint64_t off_t;
 #define _ptr(val) ((void *) (unsigned long) (val))
 #define _ul(val)  ((unsigned long) (val))

--- a/include/mm/regions.h
+++ b/include/mm/regions.h
@@ -42,27 +42,27 @@
 #include <page.h>
 #include <string.h>
 
-extern unsigned long __start_text[], __end_text[];
-extern unsigned long __start_data[], __end_data[];
-extern unsigned long __start_bss[], __end_bss[];
-extern unsigned long __start_rodata[], __end_rodata[];
+extern unsigned char __start_text[], __end_text[];
+extern unsigned char __start_data[], __end_data[];
+extern unsigned char __start_bss[], __end_bss[];
+extern unsigned char __start_rodata[], __end_rodata[];
 
-extern unsigned long __start_text_user[], __end_text_user[];
-extern unsigned long __start_data_user[], __end_data_user[];
-extern unsigned long __start_bss_user[], __end_bss_user[];
+extern unsigned char __start_text_user[], __end_text_user[];
+extern unsigned char __start_data_user[], __end_data_user[];
+extern unsigned char __start_bss_user[], __end_bss_user[];
 
-extern unsigned long __start_text_init[], __end_text_init[];
-extern unsigned long __start_data_init[], __end_data_init[];
-extern unsigned long __start_bss_init[], __end_bss_init[];
+extern unsigned char __start_text_init[], __end_text_init[];
+extern unsigned char __start_data_init[], __end_data_init[];
+extern unsigned char __start_bss_init[], __end_bss_init[];
 
-extern unsigned long __start_text_rmode[], __end_text_rmode[];
-extern unsigned long __start_data_rmode[], __end_data_rmode[];
+extern unsigned char __start_text_rmode[], __end_text_rmode[];
+extern unsigned char __start_data_rmode[], __end_data_rmode[];
 extern struct extable_entry __start_extables[], __end_extables[];
-extern unsigned long __start_bss_rmode[], __end_bss_rmode[];
+extern unsigned char __start_bss_rmode[], __end_bss_rmode[];
 
 extern struct ktf_param __start_cmdline[], __end_cmdline[];
 
-extern unsigned long __weak __start_symbols[], __end_symbols[];
+extern unsigned char __weak __start_symbols[], __end_symbols[];
 
 struct addr_range {
     const char *name;

--- a/include/mm/regions.h
+++ b/include/mm/regions.h
@@ -57,7 +57,8 @@ extern unsigned char __start_bss_init[], __end_bss_init[];
 
 extern unsigned char __start_text_rmode[], __end_text_rmode[];
 extern unsigned char __start_data_rmode[], __end_data_rmode[];
-extern struct extable_entry __start_extables[], __end_extables[];
+extern struct extable_entry __start_extables[], __stop_extables[];
+extern unsigned char __end_extables[];
 extern unsigned char __start_bss_rmode[], __end_bss_rmode[];
 
 extern struct ktf_param __start_cmdline[], __end_cmdline[];


### PR DESCRIPTION
This PR fixes the extable handling as in not triggering a panic or handling NULL pointer dereferences in an endless loop. E.g. when booting on a VM with too little memory we'll now fail gracefully instead of looping in exception handling:

```
minipli@ex:~/src/ktf (extables)$ qemu-system-x86_64 -enable-kvm -cpu host -cdrom boot.iso -serial stdio 
COM1: 3f8, COM2: 2f8
CPU: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
Frequency: 1900 MHz
Initialize Physical Memory Manager
Avail memory frames: (total size: 126 MB)
  4 KB: 2177
  2048 KB: 59
Initialize Per CPU structures
Initialize SLAB
Initializing ACPI support
ACPI: RSDP 0x00000000000F5B20 000014 (v00 BOCHS )
ACPI: RSDT 0x0000000007FE1905 000034 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
ACPI: FACP 0x0000000007FE17B9 000074 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
ACPI: DSDT 0x0000000007FE0040 001779 (v01 BOCHS  BXPC     00000001 BXPC 00000001)
RAX=0x0000000000000000  R8=0xffffffff807e6240
RBX=0x0000000007fe0000  R9=0x0000000007fe0000
RCX=0x0000000000000000 R10=0x0000000000007fe1
RDX=0xffffffff87fe0000 R11=0x00000000000003fd
RSI=0x0000000000000005 R12=0x0000000000000000
RDI=0xffffffff807e6260 R13=0x0000000000000001
RBP=0xffffffff8015d89c R14=0x0000000000000000
RSP=0xffffffff809ffe68 R15=0x0000000000000000

RIP=0xffffffff8013d270

CURRENT:
CS=0x0018 DS=0x0000 SS=0x0000
ES=0x0000 FS=0x0000 GS=0x0048
EXCEPTION:
CS=0x0018 SS=0x0000

CR0=0x0000000080010011 CR2=0xffffffff87fe0004
CR3=0x00000000007fb000 CR4=0x0000000000000030
CR8=0x0000000000000000

RFLAGS=0x0000000000010246

STACK[ffffffff809ffe68]:
0x0000: ffffffff8013f88c 0000000000000000 000000028013d4d1 0000000007fe0000 
0x0020: ffffffff87fe0000 5343414600000040 0000000000050000 0000000000000004 
0x0040: ffffffff807e6200 0000000000000074 ffffffff87fe1929 0000000000000034 
0x0060: ffffffff8013ee78 0000000000000004 ffffffff87fe17b9 0000000000000004 
0x0080: ffffffff87fe1905 0000000000000004 ffffffff801420fb ffffffff809fff48 
0x00a0: 0000000400000000 ffffffffffffffff 0000000000000000 0000000000000001 
0x00c0: 0000000000000000 0000000000000001 0000000000000000 ffffffffffffffff 
0x00e0: 000000003b9aca00 0000000000000000 ffffffff801403fb 0000000000000000 
0x0100: 0000000000000000 0000000000000000 ffffffff80154501 0000000000000067 
0x0120: 0000000000000000 0000000000000000 000000000001d000 ffffffffffffffff 
0x0140: 000000003b9aca00 0000000000000000 ffffffff80158f89 0000000000000063 
0x0160: 00000000000000ff 0000000000000000 000000000001d000 ffffffffffffffff 
0x0180: 000000003b9aca00 0000000000000000 000000000000d762 

CALLSTACK:
0xffffffff8013d270: AcpiTbInitTableDescriptor + <0x20> [0x35]
0xffffffff8013f88c: AcpiTbInstallStandardTable + <0x13c> [0x2ff]
0xffffffff8013ee78: AcpiTbParseFadt + <0xd8> [0xda]
0xffffffff801420fb: AcpiTbParseRootTable + <0x37b> [0x380]
0xffffffff801403fb: AcpiInitializeTables + <0x7b> [0x12b]
0xffffffff80154501: init_acpi + <0x51> [0x55e]
0xffffffff80158f89: kmap + <0x29> [0x2e]
0x000000000000d762: kernel_start + <0x2a2> [0xa89]

******************************
CPU[0] PANIC: #PF -RS-- at IP: 0x18:0xffffffff8013d270 SP: 0x00:0xffffffff809ffe68
******************************
```

*Boilerplate disclamer follows:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
