### PR TITLE
vmm: add missing l2_flags param to vmap_2m()

### DIFF
--- a/include/arch/x86/page.h
+++ b/include/arch/x86/page.h
@@ -194,7 +194,7 @@ static inline void *vmap_1g(void *va, mfn_t mfn, unsigned long l3_flags) {
 }
 
 static inline void *vmap_2m(void *va, mfn_t mfn, unsigned long l2_flags) {
-    return vmap(va, mfn, PAGE_ORDER_2M, L4_PROT_USER, L3_PROT_USER, PT_NO_FLAGS,
+    return vmap(va, mfn, PAGE_ORDER_2M, L4_PROT_USER, L3_PROT_USER, l2_flags,
                 PT_NO_FLAGS);
 }
 


### PR DESCRIPTION
Signed-off-by: Pawel Wieczorkiewicz <wipawel@grsecurity.net>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
