### PR TITLE
x86: Add 'l' suffix to btr/bts instructions

### DIFF
--- a/include/arch/x86/atomic.h
+++ b/include/arch/x86/atomic.h
@@ -59,7 +59,7 @@ static inline bool atomic_test_bit(unsigned int bit, volatile void *addr) {
 static inline bool atomic_test_and_set_bit(unsigned int bit, volatile void *addr) {
     bool status;
 
-    asm volatile("lock bts %[bit], %[addr];"
+    asm volatile("lock btsl %[bit], %[addr];"
                  "setc %[status];"
                  : [ status ] "=r"(status)
                  : [ bit ] "Ir"(bit), [ addr ] "m"(*(uint8_t *) addr)
@@ -71,7 +71,7 @@ static inline bool atomic_test_and_set_bit(unsigned int bit, volatile void *addr
 static inline bool atomic_test_and_reset_bit(unsigned int bit, volatile void *addr) {
     bool status;
 
-    asm volatile("lock btr %[bit], %[addr];"
+    asm volatile("lock btrl %[bit], %[addr];"
                  "setc %[status];"
                  : [ status ] "=r"(status)
                  : [ bit ] "Ir"(bit), [ addr ] "m"(*(uint8_t *) addr)


### PR DESCRIPTION
Add an explicit suffix to the btr/bts instructions within
atomic_test_and_{re,}set_bit. This addition silences the
following assembler warnings:

ktf/include/arch/x86/atomic.h:62: Warning: no instruction mnemonic suffix given and no register operands; using default for `bts'
ktf/include/arch/x86/atomic.h:74: Warning: no instruction mnemonic suffix given and no register operands; using default for `btr'

Signed-off-by: Connor Davis <connojd@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
