### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @awslabs/ktf
+* @KernelTestFramework/ktf
 


### PR DESCRIPTION
Update CODEOWNERS. The repository has been transfered from awslabs/ktf to KernelTestFramework/ktf

Signed-off-by: Daniele Ahmed <ahmeddan@amazon.de>