### PR TITLE
slab allocator: fixes/enhancements in slab allocator

### DIFF
--- a/include/mm/slab.h
+++ b/include/mm/slab.h
@@ -59,6 +59,8 @@ typedef enum slab_size slab_size_t;
 
 #define SLAB_SIZE_FULL_MASK ((SLAB_SIZE_MAX << 1) - 1)
 
+#define MAX_SLAB_ALLOC_COUNT PAGE_SIZE/SLAB_SIZE_MIN
+
 /*
  * SLAB sizes >= 4K should directly allocate pages
  */
@@ -74,10 +76,38 @@ struct meta_slab {
     list_head_t slab_head;
     void *slab_base;
     unsigned int slab_len;
-    unsigned int slab_size;
+ /*
+ * Don't need more than 12 bits. Currently max slab size is 2048 bytes = 2^11
+ */
+    unsigned int slab_size : 12;
+ /*
+ * slab_allocs is tracking number of allocations currently in this slab. 
+ * At max this can go 4096/16 = 256 slabs. Thus 10 bits are enough
+ */
+    unsigned int slab_allocs : 10;
+    unsigned int reserved : ((sizeof(unsigned int)*8) - 22);
 };
 
 typedef struct meta_slab meta_slab_t;
+
+static inline void increment_slab_allocs(meta_slab_t *slab) {
+    BUG_ON(slab == NULL);
+    BUG_ON((slab->slab_allocs >= (slab->slab_len/slab->slab_size)));
+
+    slab->slab_allocs++;
+}
+
+static inline void decrement_slab_allocs(meta_slab_t *slab) {
+    BUG_ON(slab == NULL);
+    BUG_ON((slab->slab_allocs == 0));
+
+    slab->slab_allocs--;
+}
+
+static inline bool slab_is_empty(meta_slab_t *slab) {
+    BUG_ON(slab == NULL);
+    return (slab->slab_allocs == 0);
+}
 
 int init_slab(void);
 extern void *kmalloc(size_t size);


### PR DESCRIPTION
When we first implemented slab allocator for KTF, we never cared for freeing
memory when entire slab is freed up. Reason being we thought of it as short-
running kernel. However we're into a situation where we're allocating a lot of
memory, thanks for integration of external library doing malloc and free.
This change ensures that if a slab got completly freed up, we free up the memory
and put that meta slab back into free list.

Signed-off-by: dkgupta <dkgupta@amazon.com>