### PR TITLE
Scale slab allocs2: Changes are built on top of scale_slab_allocs branch.

### DIFF
--- a/include/mm/slab.h
+++ b/include/mm/slab.h
@@ -59,6 +59,8 @@ typedef enum slab_size slab_size_t;
 
 #define SLAB_SIZE_FULL_MASK ((SLAB_SIZE_MAX << 1) - 1)
 
+#define MAX_SLAB_ALLOC_COUNT PAGE_SIZE/SLAB_SIZE_MIN
+
 /*
  * SLAB sizes >= 4K should directly allocate pages
  */
@@ -74,10 +76,39 @@ struct meta_slab {
     list_head_t slab_head;
     void *slab_base;
     unsigned int slab_len;
-    unsigned int slab_size;
+/*
+* Don't need more than 12 bits. Currently max slab size is 2048 bytes = 2^11
+*/
+    unsigned int slab_size : 12;
+/*
+* slab_allocs is tracking number of allocations currently in this slab. 
+* At max this can go 4096/16 = 256 slabs. Thus 10 bits are enough
+*/    
+    unsigned int slab_allocs : 10;
+    unsigned int reserved : ((sizeof(unsigned int)*8) - 22);
 };
 
 typedef struct meta_slab meta_slab_t;
+
+static inline void increment_slab_allocs(meta_slab_t *slab) {
+    ASSERT(slab != NULL);
+    ASSERT((slab->slab_allocs < MAX_SLAB_ALLOC_COUNT));
+    ASSERT((slab->slab_allocs < (PAGE_SIZE/slab->slab_size)));
+
+    slab->slab_allocs++;
+}
+
+static inline void decrement_slab_allocs(meta_slab_t *slab) {
+    ASSERT(slab != NULL);
+    ASSERT((slab->slab_allocs != 0));
+
+    slab->slab_allocs--;
+}
+
+static inline bool slab_is_empty(meta_slab_t *slab) {
+    ASSERT(slab != NULL);
+    return (slab->slab_allocs == 0);
+}
 
 int init_slab(void);
 extern void *kmalloc(size_t size);

--- a/include/mm/slab.h
+++ b/include/mm/slab.h
@@ -81,11 +81,11 @@ struct meta_slab {
 */
     unsigned int slab_size : 12;
 /*
-* slab_allocs is tracking number of allocations currently in this slab. 
+* slab_allocs is tracking number of allocations currently in this slab.
 * At max this can go 4096/16 = 256 slabs. Thus 10 bits are enough
-*/    
+*/
     unsigned int slab_allocs : 10;
-    unsigned int reserved : ((sizeof(unsigned int)*8) - 22);
+    unsigned int reserved : ((sizeof(unsigned int) * 8) - 22);
 };
 
 typedef struct meta_slab meta_slab_t;
@@ -93,7 +93,7 @@ typedef struct meta_slab meta_slab_t;
 static inline void increment_slab_allocs(meta_slab_t *slab) {
     ASSERT(slab != NULL);
     ASSERT((slab->slab_allocs < MAX_SLAB_ALLOC_COUNT));
-    ASSERT((slab->slab_allocs < (PAGE_SIZE/slab->slab_size)));
+    ASSERT((slab->slab_allocs < (slab->slab_len / slab->slab_size)));
 
     slab->slab_allocs++;
 }


### PR DESCRIPTION
Changes are built on top of scale_slab_allocs branch. 
scale_slab_allocs branch need to merge first.

slab allocator: enhancements in slab allocator

slab allocator was limited in the sense that it wouldn't allocate more if
meta_slab_t entries contained in globally allocated page at initializaiton
were all exhausted. This change makes a slight design change as follows:-
 - During allocation if meta_slab_t is not available then allocator will do
   - Allocate a fresh page
   - First entry is special meta_slab_t in this page
   - First entry will treat rest of meta_slab_t entries in page as normal
      meta_slab_t entry to allocate user requested memory allocations.
   - Link special meta_slab_t entry in a global list so that all such allocated
      pages are linked together

Note about special meta_slab_t entry:-
Special meta_slab_t is basically to manage meta_slab_t entries itself. It's metadata
of metadata of user allocations.