### PR TITLE
build: use hardlink for ACPICA's acktf.h file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ SHELL := bash
 RM := rm
 LN := ln
 SYMLINK := $(LN) -s -f
+HARDLINK := $(LN) -f
 OBJCOPY := objcopy
 STRIP := strip
 ifeq ($(SYSTEM), MACOS)
@@ -135,7 +136,7 @@ ifeq ($(CONFIG_ACPICA),y)
 ACPICA_INSTALL := $(shell [ -d $(ACPICA_DEST_DIR)/source ] ||                         \
                           $(TAR_CMD_ACPICA) $(ACPICA_TARBALL) $(ACPICA_UNTAR_DIRS) && \
                           $(PATCH) -p0 < $(ACPICA_PATCH) &&                           \
-                          $(SYMLINK) $(ACPICA_DEST_DIR)/acktf.h $(ACPICA_DEST_DIR)/source/include/platform/acktf.h)
+                          $(HARDLINK) $(ACPICA_DEST_DIR)/acktf.h $(ACPICA_INCLUDE)/platform/acktf.h)
 endif
 
 SOURCES     := $(shell find . -name \*.c)


### PR DESCRIPTION
Docker does not deal well with symlinks. To avoid such problems,
create a hardlink in the transient source directory of ACPICA
build.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@grsecurity.net>

Fixes: #230 