### PR TITLE
 add VIRT_KERNEL_MAP memory area

### DIFF
--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -205,18 +205,6 @@ void vunmap(void *va, unsigned int order) {
     vmap(va, MFN_INVALID, order, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS);
 }
 
-void *kmap(mfn_t mfn, unsigned int order,
-#if defined(__x86_64__)
-           unsigned long l4_flags,
-#endif
-           unsigned long l3_flags, unsigned long l2_flags, unsigned long l1_flags) {
-    return vmap(mfn_to_virt_kern(mfn), mfn, order,
-#if defined(__x86_64__)
-                l4_flags,
-#endif
-                l3_flags, l2_flags, l1_flags);
-}
-
 void init_pagetables(void) {
     for_each_memory_range (r) {
         switch (r->base) {

--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -201,9 +201,8 @@ done:
     return va;
 }
 
-void *vunmap(void *va, unsigned int order) {
-    return vmap(va, MFN_INVALID, order, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS,
-                PT_NO_FLAGS);
+void vunmap(void *va, unsigned int order) {
+    vmap(va, MFN_INVALID, order, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS);
 }
 
 void *kmap(mfn_t mfn, unsigned int order,
@@ -216,11 +215,6 @@ void *kmap(mfn_t mfn, unsigned int order,
                 l4_flags,
 #endif
                 l3_flags, l2_flags, l1_flags);
-}
-
-void *kunmap(void *va, unsigned int order) {
-    return vmap(va, MFN_INVALID, order, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS,
-                PT_NO_FLAGS);
 }
 
 void init_pagetables(void) {

--- a/common/acpi.c
+++ b/common/acpi.c
@@ -154,7 +154,7 @@ static void acpi_table_unmap_pages(void *addr, unsigned mapped_pages) {
     mfn_t mfn = virt_to_mfn(addr);
 
     for (unsigned i = 0; i < mapped_pages; i++, mfn++) {
-        kunmap(mfn_to_virt_kern(mfn), PAGE_ORDER_4K);
+        vunmap(mfn_to_virt_kern(mfn), PAGE_ORDER_4K);
     }
 }
 

--- a/drivers/acpi/acpica/osl.c
+++ b/drivers/acpi/acpica/osl.c
@@ -270,7 +270,7 @@ void AcpiOsUnmapMemory(void *LogicalAddress, ACPI_SIZE Length) {
     mfn_t mfn = virt_to_mfn(LogicalAddress);
 
     for (unsigned i = 0; i < num_pages; i++, mfn++)
-        kunmap(mfn_to_virt_kern(mfn), PAGE_ORDER_4K);
+        vunmap(mfn_to_virt_kern(mfn), PAGE_ORDER_4K);
 }
 
 /* Task management functions */

--- a/include/arch/x86/page.h
+++ b/include/arch/x86/page.h
@@ -139,14 +139,13 @@ extern void *vmap(void *va, mfn_t mfn, unsigned int order,
                   unsigned long l4_flags,
 #endif
                   unsigned long l3_flags, unsigned long l2_flags, unsigned long l1_flags);
-extern void *vunmap(void *va, unsigned int order);
 
 extern void *kmap(mfn_t mfn, unsigned int order,
 #if defined(__x86_64__)
                   unsigned long l4_flags,
 #endif
                   unsigned long l3_flags, unsigned long l2_flags, unsigned long l1_flags);
-extern void *kunmap(void *va, unsigned int order);
+extern void vunmap(void *va, unsigned int order);
 
 /* Static declarations */
 

--- a/include/arch/x86/page.h
+++ b/include/arch/x86/page.h
@@ -140,11 +140,6 @@ extern void *vmap(void *va, mfn_t mfn, unsigned int order,
 #endif
                   unsigned long l3_flags, unsigned long l2_flags, unsigned long l1_flags);
 
-extern void *kmap(mfn_t mfn, unsigned int order,
-#if defined(__x86_64__)
-                  unsigned long l4_flags,
-#endif
-                  unsigned long l3_flags, unsigned long l2_flags, unsigned long l1_flags);
 extern void vunmap(void *va, unsigned int order);
 
 /* Static declarations */
@@ -186,6 +181,19 @@ static inline paddr_t virt_to_paddr(const void *va) {
 
 static inline mfn_t virt_to_mfn(const void *va) {
     return paddr_to_mfn(virt_to_paddr(va));
+}
+
+static inline void *kmap(mfn_t mfn, unsigned int order,
+#if defined(__x86_64__)
+                         unsigned long l4_flags,
+#endif
+                         unsigned long l3_flags, unsigned long l2_flags,
+                         unsigned long l1_flags) {
+    return vmap(mfn_to_virt_kern(mfn), mfn, order,
+#if defined(__x86_64__)
+                l4_flags,
+#endif
+                l3_flags, l2_flags, l1_flags);
 }
 
 static inline void *vmap_1g(void *va, mfn_t mfn, unsigned long l3_flags) {

--- a/include/mm/vmm.h
+++ b/include/mm/vmm.h
@@ -31,6 +31,7 @@ enum gfp_flags {
     GFP_KERNEL = 0x00000001,
     GFP_USER = 0x00000002,
     GFP_IDENT = 0x00000004,
+    GFP_KERNEL_MAP = 0x00000008,
 };
 
 /* External definitions */

--- a/mm/vmm.c
+++ b/mm/vmm.c
@@ -50,6 +50,8 @@ void *get_free_pages(unsigned int order, uint32_t flags) {
                   L2_PROT_USER, L1_PROT_USER);
     if (flags & GFP_KERNEL)
         va = kmap(mfn, order, L4_PROT, L3_PROT, L2_PROT, L1_PROT);
+    if (flags & GFP_KERNEL_MAP)
+        va = mmap(mfn, order, L4_PROT, L3_PROT, L2_PROT, L1_PROT);
 
     return va;
 }


### PR DESCRIPTION
    The VIRT_KERNEL_MAP is currently located at the address 0xffff800000000000.
    The memory area should be used for high-address or large memory allocations.
    The VIRT_KERNEL_BASE area, while reachable from within the VIRT_IDENT_BASE
    area, does not have enough addressing space for high address allocations
    (base address overflow). All such allocations should go to the new area.
    
    Add mmap() helper (or its order size variants) to automatically use the
    VIRT_KERNEL_MAP area.
    
    The get_free_pages() gets a new flag GPF_KERNEL_MAP to use the area.
