### PR TITLE
Add refcount tracking for ACPICA's mappings and use VIRT_KERNEL_MAP area 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ endif
 ifeq ($(HAVE_KVM), kvm)
 QEMU_PARAMS += -enable-kvm
 endif # HAVE_KVM
-QEMU_PARAMS += -m 8192
+QEMU_PARAMS += -m 128
 QEMU_PARAMS += -display none -vga none -vnc none
 QEMU_PARAMS += -serial stdio
 QEMU_PARAMS += -smp cpus=2


### PR DESCRIPTION
    ACPICA maps and unmaps memory in chunks whose address (or size) might not
    be PAGE_SIZE aligned. It might for example map memory at address 0x00 and
    map another chunk at address 0x40. KTF performs memory (un)mapping using
    PAGE_SIZE aligned memory frames. If ACPICA allocates memory at 0x00 and 0x40,
    KTF maps the same physical frame to the same virtual address twice.
    This does not hurt, but ACPICA can unmap the memory chunk at address 0x40
    and assume the chunk at 0x00 is still mapped. KTF will simply unmap entire
    frame.
    
    As of now KTF does not need to track mapped frames refcounting based on
    smaller granularity than PAGE_SIZE. If a 4K frame is mapped (even multiple
    times) and then unmapped once, the frame should be unmapped as a result.
    
    To make ACPICA work with this, add mapped_frames list tracking ACPICA
    mapped frames with refcounting. If a frame is mapped several times, it gets
    really unmapped only if the same number of times it has been unmapped by
    ACPICA.
    
