### PR TITLE
PMM: add simple buddy allocator (splitting and merging frames)

### DIFF
--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -60,6 +60,8 @@ typedef struct frames_array frames_array_t;
 
 typedef bool (*free_frames_cond_t)(frame_t *free_frame);
 
+#define ORDER_TO_SIZE(order) (PAGE_SIZE << (order))
+
 #define FIRST_FRAME_SIBLING(mfn, order) ((mfn) % (1UL << (order)) == 0)
 #define NEXT_MFN(mfn, order)            ((mfn) + (1UL << (order)))
 #define PREV_MFN(mfn, order)            ((mfn) - (1UL << (order)))

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -80,6 +80,10 @@ static inline bool paddr_invalid(paddr_t pa) {
 
 static inline bool mfn_invalid(mfn_t mfn) { return paddr_invalid(mfn_to_paddr(mfn)); }
 
+static inline bool has_frames(list_head_t *frames, unsigned int order) {
+    return !(order > MAX_PAGE_ORDER || list_is_empty(&frames[order]));
+}
+
 static inline frame_t *get_free_frame(void) { return get_free_frames(PAGE_ORDER_4K); }
 static inline void put_free_frame(mfn_t mfn) {
     return put_free_frames(mfn, PAGE_ORDER_4K);

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -60,8 +60,9 @@ typedef struct frames_array frames_array_t;
 
 typedef bool (*free_frames_cond_t)(frame_t *free_frame);
 
-#define NEXT_MFN(mfn, order) ((mfn) + (1UL << (order)))
-#define PREV_MFN(mfn, order) ((mfn) - (1UL << (order)))
+#define FIRST_FRAME_SIBLING(mfn, order) ((mfn) % (1UL << (order)) == 0)
+#define NEXT_MFN(mfn, order)            ((mfn) + (1UL << (order)))
+#define PREV_MFN(mfn, order)            ((mfn) - (1UL << (order)))
 
 /* External definitions */
 

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -60,6 +60,9 @@ typedef struct frames_array frames_array_t;
 
 typedef bool (*free_frames_cond_t)(frame_t *free_frame);
 
+#define NEXT_MFN(mfn, order) ((mfn) + (1UL << (order)))
+#define PREV_MFN(mfn, order) ((mfn) - (1UL << (order)))
+
 /* External definitions */
 
 extern void display_frames_count(void);
@@ -82,6 +85,13 @@ static inline bool mfn_invalid(mfn_t mfn) { return paddr_invalid(mfn_to_paddr(mf
 
 static inline bool has_frames(list_head_t *frames, unsigned int order) {
     return !(order > MAX_PAGE_ORDER || list_is_empty(&frames[order]));
+}
+
+static inline frame_t *get_first_frame(list_head_t *frames, unsigned int order) {
+    if (!has_frames(frames, order))
+        return NULL;
+
+    return list_first_entry(&frames[order], frame_t, list);
 }
 
 static inline frame_t *get_free_frame(void) { return get_free_frames(PAGE_ORDER_4K); }

--- a/mm/pmm.c
+++ b/mm/pmm.c
@@ -376,6 +376,20 @@ static inline frame_t *return_frame(frame_t *frame) {
     return frame;
 }
 
+static frame_t *find_mfn_frame(list_head_t *frames, mfn_t mfn, unsigned int order) {
+    frame_t *frame;
+
+    if (!has_frames(frames, order))
+        return NULL;
+
+    list_for_each_entry (frame, &frames[order], list) {
+        if (frame->mfn == mfn)
+            return frame;
+    }
+
+    return NULL;
+}
+
 /* Reserves and returns the first free frame fulfilling
  * the condition specified by the callback
  */

--- a/mm/pmm.c
+++ b/mm/pmm.c
@@ -172,8 +172,8 @@ static inline frame_t *take_frame(frame_t *frame, frames_array_t *array) {
     return frame;
 }
 
-static inline frame_t *put_frame(frame_t *frame, frames_array_t *array) {
-    ASSERT(!frame);
+static inline frame_t *put_frames_array_entry(frame_t *frame, frames_array_t *array) {
+    BUG_ON(is_frame_free(frame));
 
     if (!array)
         array = find_frames_array(frame);
@@ -204,11 +204,15 @@ static inline frame_t *get_frames_array_entry(void) {
     return NULL;
 }
 
-static inline void put_frames_array_entry(frame_t *frame) {
-    if (is_frame_free(frame))
-        return;
+static inline void destroy_frame(frame_t *frame) {
+    BUG_ON(is_frame_used(frame));
 
-    put_frame(frame, NULL);
+    if (frame) {
+        list_unlink(&frame->list);
+        frames_count[frame->order]--;
+
+        put_frames_array_entry(frame, NULL);
+    }
 }
 
 static inline frame_t *new_frame(mfn_t mfn, unsigned int order) {

--- a/mm/pmm.c
+++ b/mm/pmm.c
@@ -376,17 +376,18 @@ static inline frame_t *return_frame(frame_t *frame) {
  * the condition specified by the callback
  */
 frame_t *get_free_frames_cond(free_frames_cond_t cb) {
-    frame_t *frame;
-
     spin_lock(&lock);
     for_each_order (order) {
+        frame_t *frame;
+
         if (list_is_empty(&free_frames[order]))
             continue;
 
         list_for_each_entry (frame, &free_frames[order], list) {
             if (cb(frame)) {
+                reserve_frame(frame);
                 spin_unlock(&lock);
-                return reserve_frame(frame);
+                return frame;
             }
         }
     }


### PR DESCRIPTION
The split_frame() breaks given frame into two smaller frames.
Original frame's frame_t struct is reused, frame order is decremented
and the struct is re-assigned to lower order free frame list.
Another, new frame is created for the second half of the original frame.
    
The get_free_frame(), when cannot find free frame of requested order,
keeps finding first free higher-order frame and split it, until desired
order frame becomes available.
    
The merge_frames() attempts to merge two consecutive frames into a higher
order frame. It only merges higher-order aligned frame with its following
frame. To do so, it checks if the frame being returned is higher-order
aligned frame and attempts to find its following frame. If the frame
being returned is not higher-order aligned, it tries to find its preceding
frame, which will be properly aligned.
When the two frames are found, the first frame's struct is reused, order
is incremented and the struct is relinked to higher order free frames list.
The second frame struct is destroyed.
    
The merge_frames() calls itself recursively in attempt to merge all merge-
able higher-order frames for all orders.
    
The put_free_frames() find corresponding frame struct for given MFN and
order. If the frame is fully returned (there is no more references) and
relinked from busy_frames to free_frames, it attempts to merge the frame.
    
After creating early frames, the process_memory_range() finds highest
available frame order (i.e. frame order whose size fits into available
physical memory size).
Instead of creating 2M frames by default, it creates frames of the
detected order and uses the rest of available space to create 2M frames
and 4K frames.

Implements #7.
