### PR TITLE
cpuid: move functions from cpuid.h into cpuid.c

### DIFF
--- a/arch/x86/cpuid.c
+++ b/arch/x86/cpuid.c
@@ -22,17 +22,12 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef KTF_CPUID_H
-#define KTF_CPUID_H
 
+#include <cpuid.h>
+#include <ktf.h>
 #include <string.h>
 
-/* CPU vendor detection */
-#define CPUID_EXT_INFO_LEAF  0x80000000U
-#define CPUID_BRAND_INFO_MIN 0x80000002U
-#define CPUID_BRAND_INFO_MAX 0x80000004U
-
-static uint64_t get_cpu_freq(const char *cpu_str) {
+uint64_t get_cpu_freq(const char *cpu_str) {
     size_t len = strlen(cpu_str);
     uint64_t frequency = 0;
     char buf[16];
@@ -96,7 +91,7 @@ static uint64_t get_cpu_freq(const char *cpu_str) {
     return frequency;
 }
 
-static inline bool cpu_vendor_string(char *cpu_str) {
+bool cpu_vendor_string(char *cpu_str) {
     uint32_t leaf = CPUID_EXT_INFO_LEAF;
     uint32_t ebx = 0, ecx = 0, edx = 0;
     uint32_t eax = cpuid_eax(leaf);
@@ -117,5 +112,3 @@ static inline bool cpu_vendor_string(char *cpu_str) {
 
     return true;
 }
-
-#endif /* KTF_CPUID_H */

--- a/common/setup.c
+++ b/common/setup.c
@@ -66,8 +66,6 @@ boot_flags_t boot_flags;
 
 static unsigned bsp_cpu_id = 0;
 
-char cpu_identifier[49];
-
 unsigned get_bsp_cpu_id(void) { return bsp_cpu_id; }
 void set_bsp_cpu_id(unsigned cpu_id) { bsp_cpu_id = cpu_id; }
 
@@ -112,6 +110,19 @@ static void __text_init map_bios_area(void) {
         kmap_4k(bios_mfn, L1_PROT_RO);
 }
 
+static void display_cpu_info(void) {
+    char cpu_identifier[49];
+    unsigned long freq;
+
+    if (!cpu_vendor_string(cpu_identifier))
+        return;
+
+    printk("CPU: %.48s\n", cpu_identifier);
+    freq = get_cpu_freq(cpu_identifier);
+    if (freq > 0)
+        printk("Frequency: %lu MHz\n", freq / MHZ(1));
+}
+
 static void __text_init init_vga_console(void) {
     if (!boot_flags.vga)
         return;
@@ -142,12 +153,7 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic,
     init_real_mode();
 
     /* Print cpu vendor info */
-    if (cpu_vendor_string(cpu_identifier)) {
-        printk("CPU: %.48s\n", cpu_identifier);
-        unsigned long freq = get_cpu_freq(cpu_identifier);
-        if (freq > 0)
-            printk("Frequency: %lu MHz\n", freq / MHZ(1));
-    }
+    display_cpu_info();
 
     /* Initialize Programmable Interrupt Controller */
     init_pic();

--- a/include/arch/x86/cpuid.h
+++ b/include/arch/x86/cpuid.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020 Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef KTF_CPUID_H
+#define KTF_CPUID_H
+
+#include <ktf.h>
+
+/* CPU vendor detection */
+#define CPUID_EXT_INFO_LEAF  0x80000000U
+#define CPUID_BRAND_INFO_MIN 0x80000002U
+#define CPUID_BRAND_INFO_MAX 0x80000004U
+
+extern uint64_t get_cpu_freq(const char *cpu_str);
+extern bool cpu_vendor_string(char *cpu_str);
+
+#endif /* KTF_CPUID_H */


### PR DESCRIPTION
Functions in cpuid.h deserve their own C file and should not be inlined. The CPUID functionality should also go to arch/x86 directories.