### PR TITLE
Use grub-mkrescue to create Legacy BIOS and EFI bootable ISO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cscope.*
 Makeconf.local
 .DS_Store
 *.swp
+*.xz
 drivers/acpi/acpica/source/
 third-party/libpfm/COPYING
 third-party/libpfm/Makefile

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ endif
 
 GRUB_DIR := grub/boot
 GRUB_FILE := grub-file
-GRUB_MKIMAGE := grub-mkimage
-GRUB_MODULES := multiboot iso9660 biosdisk
+GRUB_MKRESCUE := grub-mkrescue
+GRUB_MODULES := multiboot iso9660 serial normal
 ifneq ($(UNITTEST),)
 GRUB_CONFIG := $(GRUB_DIR)/grub/grub-test.cfg
 else
@@ -257,8 +257,7 @@ $(ISO_FILE): $(TARGET)
 	$(VERBOSE) $(GRUB_FILE) --is-x86-multiboot $(TARGET) || { echo "Multiboot not supported"; exit 1; }
 	$(VERBOSE) cp $(TARGET) $(GRUB_DIR)/
 	$(VERBOSE) $(XZ) -q -f $(GRUB_DIR)/$(TARGET)
-	$(VERBOSE) $(GRUB_MKIMAGE) --format i386-pc-eltorito -c $(GRUB_CONFIG) -p /boot/grub -o grub/boot.img $(GRUB_MODULES)
-	$(VERBOSE) $(XORRISO) -as mkisofs -U -b boot.img -no-emul-boot -boot-load-size 4 -boot-info-table -o $(ISO_FILE) grub 2>> /dev/null
+	$(VERBOSE) $(GRUB_MKRESCUE) --install-modules="$(GRUB_MODULES)" --fonts=no --compress=xz -o $(ISO_FILE) grub &> /dev/null
 endif
 
 .PHONY: boot

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ endif
 XORRISO := xorriso
 QEMU_BIN := qemu-system-x86_64
 GDB := gdb
+XZ := xz
 
 COMMON_INCLUDES := -I$(KTF_ROOT)/include -I$(KTF_ROOT)/include/arch/x86
 ifeq ($(CONFIG_LIBPFM),y)
@@ -216,6 +217,7 @@ clean:
 	$(VERBOSE) find $(KTF_ROOT) -name \*.bin -delete
 	$(VERBOSE) find $(KTF_ROOT) -name \*.iso -delete
 	$(VERBOSE) find $(KTF_ROOT) -name \*.img -delete
+	$(VERBOSE) find $(KTF_ROOT) -name \*.xz -delete
 	$(VERBOSE) find $(KTF_ROOT) -name cscope.\* -delete
 	$(VERBOSE) find $(PFMLIB_DIR) -mindepth 1 ! -name $(PFMLIB_NAME)-$(PFMLIB_VER).tar.gz -delete
 	$(VERBOSE) $(RM) -rf $(ACPICA_DEST_DIR)/source
@@ -254,6 +256,7 @@ $(ISO_FILE): $(TARGET)
 	@echo "GEN ISO" $(ISO_FILE)
 	$(VERBOSE) $(GRUB_FILE) --is-x86-multiboot $(TARGET) || { echo "Multiboot not supported"; exit 1; }
 	$(VERBOSE) cp $(TARGET) $(GRUB_DIR)/
+	$(VERBOSE) $(XZ) -q -f $(GRUB_DIR)/$(TARGET)
 	$(VERBOSE) $(GRUB_MKIMAGE) --format i386-pc-eltorito -c $(GRUB_CONFIG) -p /boot/grub -o grub/boot.img $(GRUB_MODULES)
 	$(VERBOSE) $(XORRISO) -as mkisofs -U -b boot.img -no-emul-boot -boot-load-size 4 -boot-info-table -o $(ISO_FILE) grub 2>> /dev/null
 endif

--- a/Makefile
+++ b/Makefile
@@ -87,13 +87,14 @@ else
 STRIP_OPTS := -s
 endif
 
+GRUB_DIR := grub/boot
 GRUB_FILE := grub-file
 GRUB_MKIMAGE := grub-mkimage
 GRUB_MODULES := multiboot iso9660 biosdisk
 ifneq ($(UNITTEST),)
-GRUB_CONFIG := grub/boot/grub/grub-test.cfg
+GRUB_CONFIG := $(GRUB_DIR)/grub/grub-test.cfg
 else
-GRUB_CONFIG := grub/boot/grub/grub.cfg
+GRUB_CONFIG := $(GRUB_DIR)/grub/grub.cfg
 endif
 XORRISO := xorriso
 QEMU_BIN := qemu-system-x86_64
@@ -252,7 +253,7 @@ else
 $(ISO_FILE): $(TARGET)
 	@echo "GEN ISO" $(ISO_FILE)
 	$(VERBOSE) $(GRUB_FILE) --is-x86-multiboot $(TARGET) || { echo "Multiboot not supported"; exit 1; }
-	$(VERBOSE) cp $(TARGET) grub/boot/
+	$(VERBOSE) cp $(TARGET) $(GRUB_DIR)/
 	$(VERBOSE) $(GRUB_MKIMAGE) --format i386-pc-eltorito -c $(GRUB_CONFIG) -p /boot/grub -o grub/boot.img $(GRUB_MODULES)
 	$(VERBOSE) $(XORRISO) -as mkisofs -U -b boot.img -no-emul-boot -boot-load-size 4 -boot-info-table -o $(ISO_FILE) grub 2>> /dev/null
 endif

--- a/grub/boot/grub/grub.cfg
+++ b/grub/boot/grub/grub.cfg
@@ -1,10 +1,11 @@
 set timeout=0
 set default=0
+
 serial --speed=115200 --word=8 --parity=no --stop=1
 terminal_input --append serial
 terminal_output --append serial
 
 menuentry "kernel64" {
-   multiboot /boot/kernel64.bin poweroff=1 com1=0x3f8,115200,8,n,1
+   multiboot /boot/kernel64.bin.xz poweroff=1 com1=0x3f8,115200,8,n,1
    boot
 }


### PR DESCRIPTION
* Compress kernel image with XZ to minimize the ISO size
* Use grub-mkrescue to install and compress all grub modules needed to boot on legacy BIOS and EFI
* Install serial grub module to get the serial interface working