### PR TITLE
tasks: make tasks functions return unsigned long value

### DIFF
--- a/common/sched.c
+++ b/common/sched.c
@@ -202,7 +202,7 @@ static void run_task(task_t *task) {
     printk("CPU[%u]: Running task %s[%u]\n", task->cpu, task->name, task->id);
 
     set_task_state(task, TASK_STATE_RUNNING);
-    task->func(task->arg);
+    task->result = task->func(task->arg);
     set_task_state(task, TASK_STATE_DONE);
 }
 

--- a/include/ktf.h
+++ b/include/ktf.h
@@ -45,7 +45,7 @@ extern bool opt_debug;
 extern int usermode_call(user_func_t fn, void *fn_arg);
 
 extern void kernel_main(void) __noreturn;
-extern void test_main(void *unused);
+extern unsigned long test_main(void *unused);
 
 #endif /* __ASSEMBLY__ */
 

--- a/include/sched.h
+++ b/include/sched.h
@@ -30,7 +30,7 @@
 #include <list.h>
 #include <page.h>
 
-typedef void (*task_func_t)(void *arg);
+typedef unsigned long (*task_func_t)(void *arg);
 
 enum task_state {
     TASK_STATE_NEW,

--- a/tests/test.c
+++ b/tests/test.c
@@ -59,7 +59,7 @@ static get_next_test_result_t get_next_test(test_fn **out_test_fn, char **out_na
     return TESTS_DONE;
 }
 
-void test_main(void *unused) {
+unsigned long test_main(void *unused) {
     char *name;
     test_fn *fn = NULL;
     unsigned n = 0;
@@ -76,4 +76,5 @@ void test_main(void *unused) {
     }
 
     printk("Tests completed: %u\n", n);
+    return 0;
 }


### PR DESCRIPTION
Tasks execute functions and now the functions can return a value,
which is stored in task structure's result field.

Signed-off-by: Pawel Wieczorkiewicz <wipawel@grsecurity.net>