### PR TITLE
smp: add an abstraction handling detected CPUs' metadata

### DIFF
--- a/arch/x86/traps.c
+++ b/arch/x86/traps.c
@@ -119,8 +119,8 @@ static void init_gdt(percpu_t *percpu) {
     init_tss(percpu);
 }
 
-void init_traps(unsigned int cpu) {
-    percpu_t *percpu = get_percpu_page(cpu);
+void init_traps(const cpu_t *cpu) {
+    percpu_t *percpu = cpu->percpu;
 
     BUG_ON(!percpu);
 
@@ -175,7 +175,7 @@ void init_traps(unsigned int cpu) {
 
     init_gdt(percpu);
 
-    wrmsr(MSR_TSC_AUX, cpu);
+    wrmsr(MSR_TSC_AUX, cpu->id);
 }
 
 static void dump_general_regs(const struct cpu_regs *regs) {

--- a/common/cpu.c
+++ b/common/cpu.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2022 Open Source Security, Inc.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <console.h>
+#include <cpu.h>
+#include <ktf.h>
+#include <lib.h>
+#include <list.h>
+#include <spinlock.h>
+#include <string.h>
+
+#include <mm/slab.h>
+
+static list_head_t cpus;
+static unsigned int nr_cpus = 0;
+
+static cpu_t bsp = {0};
+
+static void init_cpu(cpu_t *cpu, unsigned int id, bool bsp, bool enabled) {
+    memset(cpu, 0, sizeof(*cpu));
+    cpu->id = id;
+    cpu->bsp = bsp;
+    cpu->enabled = enabled;
+    cpu->done = false;
+
+    cpu->percpu = get_percpu_page(id);
+    BUG_ON(!cpu->percpu);
+
+    cpu->lock = SPINLOCK_INIT;
+}
+
+cpu_t *init_cpus(void) {
+    printk("Initialize CPU structures\n");
+
+    list_init(&cpus);
+
+    init_cpu(&bsp, 0, true, true);
+    list_add(&bsp.list, &cpus);
+    nr_cpus = 1;
+
+    return &bsp;
+}
+
+cpu_t *add_cpu(unsigned int id, bool bsp, bool enabled) {
+    cpu_t *cpu = kzalloc(sizeof(*cpu));
+
+    if (!cpu)
+        return NULL;
+
+    init_cpu(cpu, id, bsp, enabled);
+
+    list_add(&cpu->list, &cpus);
+    nr_cpus++;
+
+    return cpu;
+}
+
+cpu_t *get_cpu(unsigned int id) {
+    cpu_t *cpu;
+
+    list_for_each_entry (cpu, &cpus, list) {
+        if (cpu->id == id)
+            return cpu;
+    }
+
+    return NULL;
+}
+
+unsigned int get_nr_cpus(void) { return nr_cpus; }
+
+cpu_t *get_bsp_cpu(void) { return &bsp; }
+
+void for_each_cpu(void (*func)(cpu_t *cpu)) {
+    cpu_t *cpu;
+
+    list_for_each_entry (cpu, &cpus, list)
+        func(cpu);
+}
+
+void wait_for_all_cpus(void) {
+    cpu_t *cpu, *safe;
+
+    do {
+        list_for_each_entry_safe (cpu, safe, &cpus, list) {
+            spin_lock(&cpu->lock);
+            if (cpu->done)
+                list_unlink(&cpu->list);
+            spin_unlock(&cpu->lock);
+        }
+    } while (!list_is_empty(&cpus));
+}

--- a/drivers/hpet.c
+++ b/drivers/hpet.c
@@ -27,7 +27,7 @@
 #include <drivers/hpet.h>
 #include <ioapic.h>
 
-bool init_hpet(uint8_t dst_cpus) {
+bool init_hpet(const cpu_t *cpu) {
 #ifndef KTF_ACPICA
     acpi_hpet_t *hpet;
 #else
@@ -99,7 +99,7 @@ bool init_hpet(uint8_t dst_cpus) {
     general->leg_repl_cfg = 0; /* Disable legacy route */
     general->enabled = 1;
 
-    configure_isa_irq(HPET_IRQ, HPET_IRQ_OFFSET, IOAPIC_DEST_MODE_PHYSICAL, dst_cpus);
+    configure_isa_irq(HPET_IRQ, HPET_IRQ_OFFSET, IOAPIC_DEST_MODE_PHYSICAL, cpu->id);
     dprintk("Initialized HPET\n");
     return true;
 }

--- a/drivers/keyboard.c
+++ b/drivers/keyboard.c
@@ -62,7 +62,7 @@ typedef struct keyboard_state keyboard_state_t;
 
 static keyboard_state_t keyboard_state;
 
-void init_keyboard(uint8_t dst_cpus) {
+void init_keyboard(const cpu_t *cpu) {
     if (!boot_flags.i8042) {
         dprintk("No i8042 microcontroller detected\n");
         return;
@@ -144,7 +144,7 @@ void init_keyboard(uint8_t dst_cpus) {
         outb(KEYBOARD_PORT_DATA, current_status.config);
 
         configure_isa_irq(KEYBOARD_PORT1_IRQ, KEYBOARD_PORT1_IRQ0_OFFSET,
-                          IOAPIC_DEST_MODE_PHYSICAL, dst_cpus);
+                          IOAPIC_DEST_MODE_PHYSICAL, cpu->id);
         outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_ENABLE_PORT_1);
     }
     else {
@@ -154,7 +154,7 @@ void init_keyboard(uint8_t dst_cpus) {
         outb(KEYBOARD_PORT_DATA, current_status.config);
 
         configure_isa_irq(KEYBOARD_PORT2_IRQ, KEYBOARD_PORT2_IRQ0_OFFSET,
-                          IOAPIC_DEST_MODE_PHYSICAL, dst_cpus);
+                          IOAPIC_DEST_MODE_PHYSICAL, cpu->id);
         outb(KEYBOARD_PORT_CMD, KEYBOARD_CMD_ENABLE_PORT_2);
     }
 

--- a/drivers/pit.c
+++ b/drivers/pit.c
@@ -30,12 +30,12 @@
 #include <lib.h>
 #include <time.h>
 
-void init_pit(uint8_t dst_cpus) {
+void init_pit(const cpu_t *cpu) {
     printk("Initializing PIT\n");
     outb(PIT_COMMAND_PORT, PIT_CHANNEL_0 | PIT_ACCESS_MODE_LH | PIT_OP_MODE_RATE);
     outb(PIT_DATA_PORT_CH0, PIT_FREQUENCY & 0xFF);          /* send low byte */
     outb(PIT_DATA_PORT_CH0, (PIT_FREQUENCY & 0xFF00) >> 8); /* send high byte */
-    configure_isa_irq(PIT_IRQ, PIT_IRQ0_OFFSET, IOAPIC_DEST_MODE_PHYSICAL, dst_cpus);
+    configure_isa_irq(PIT_IRQ, PIT_IRQ0_OFFSET, IOAPIC_DEST_MODE_PHYSICAL, cpu->id);
 }
 
 void pit_disable(void) { pic_disable_irq(PIC1_DEVICE_SEL, PIT_IRQ); }

--- a/drivers/serial.c
+++ b/drivers/serial.c
@@ -155,15 +155,15 @@ void __text_init init_uart(uart_config_t *cfg) {
         com_ports[0] = cfg->port;
 }
 
-void __text_init init_uart_input(uint8_t dst_cpus) {
+void __text_init init_uart_input(const cpu_t *cpu) {
     /* Initialize input state */
     memset(&input_state, 0, sizeof(input_state));
 
     /* Enable IRQ lines */
     printk("Enabling serial input\n");
 
-    configure_isa_irq(COM1_IRQ, COM1_IRQ0_OFFSET, IOAPIC_DEST_MODE_PHYSICAL, dst_cpus);
-    configure_isa_irq(COM2_IRQ, COM2_IRQ0_OFFSET, IOAPIC_DEST_MODE_PHYSICAL, dst_cpus);
+    configure_isa_irq(COM1_IRQ, COM1_IRQ0_OFFSET, IOAPIC_DEST_MODE_PHYSICAL, cpu->id);
+    configure_isa_irq(COM2_IRQ, COM2_IRQ0_OFFSET, IOAPIC_DEST_MODE_PHYSICAL, cpu->id);
 }
 
 static inline int uart_port_status(io_port_t port) {

--- a/include/acpi_ktf.h
+++ b/include/acpi_ktf.h
@@ -267,7 +267,7 @@ typedef struct acpi_madt acpi_madt_t;
 /* External Declarations */
 
 extern acpi_table_t *acpi_find_table(uint32_t signature);
-extern int init_acpi(unsigned bsp_cpu_id);
+extern int init_acpi(void);
 
 #else /* KTF_ACPICA */
 
@@ -289,7 +289,7 @@ extern void *acpi_find_table(char *signature);
 extern void acpi_walk_subtables(ACPI_SUBTABLE_HEADER *entry, uint32_t length,
                                 acpi_subtable_parser_t parser, void *arg);
 
-extern ACPI_STATUS init_acpi(unsigned bsp_cpu_id);
+extern ACPI_STATUS init_acpi(void);
 extern void acpi_power_off(void);
 
 #endif /* KTF_ACPICA */

--- a/include/arch/x86/apic.h
+++ b/include/arch/x86/apic.h
@@ -457,7 +457,7 @@ typedef union apic_self_ipi apic_self_ipi_t;
 extern uint64_t apic_read(unsigned int reg);
 extern void apic_write(unsigned int reg, uint64_t val);
 extern apic_mode_t apic_get_mode(void);
-extern void init_apic(unsigned int cpu, apic_mode_t mode);
+extern void init_apic(unsigned int cpu_id, apic_mode_t mode);
 extern apic_icr_t apic_icr_read(void);
 extern void apic_icr_write(const apic_icr_t *icr);
 

--- a/include/arch/x86/traps.h
+++ b/include/arch/x86/traps.h
@@ -33,8 +33,9 @@
 #define X86_RET2KERN_INT 32
 
 #ifndef __ASSEMBLY__
+#include <cpu.h>
 
-extern void init_traps(unsigned int cpu);
+extern void init_traps(const cpu_t *cpu);
 extern void init_boot_traps(void);
 extern void init_rmode_traps(void);
 

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2022 Open Source Security, Inc.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef KTF_CPU_H
+#define KTF_CPU_H
+
+#include <ktf.h>
+#include <lib.h>
+#include <list.h>
+#include <percpu.h>
+#include <spinlock.h>
+
+struct cpu {
+    list_head_t list;
+
+    unsigned int id;
+    unsigned int bsp : 1, enabled : 1, done : 1;
+
+    percpu_t *percpu;
+
+    spinlock_t lock;
+};
+typedef struct cpu cpu_t;
+
+/* External declarations */
+
+extern cpu_t *init_cpus(void);
+extern cpu_t *add_cpu(unsigned int id, bool bsp, bool enabled);
+extern cpu_t *get_cpu(unsigned int id);
+extern cpu_t *get_bsp_cpu(void);
+extern unsigned int get_nr_cpus(void);
+extern void for_each_cpu(void (*func)(cpu_t *cpu));
+extern void wait_for_all_cpus(void);
+
+#endif /* KTF_CPU_H */

--- a/include/drivers/hpet.h
+++ b/include/drivers/hpet.h
@@ -27,6 +27,8 @@
 #ifndef KTF_HPET_H
 #define KTF_HPET_H
 
+#include <cpu.h>
+
 #ifndef KTF_ACPICA
 #include <acpi_ktf.h>
 #else
@@ -109,6 +111,6 @@ enum {
 
 /* External Declarations */
 
-extern bool init_hpet(uint8_t dst_cpus);
+extern bool init_hpet(const cpu_t *cpu);
 
 #endif /* KTF_HPET_H */

--- a/include/drivers/keyboard.h
+++ b/include/drivers/keyboard.h
@@ -25,6 +25,7 @@
 #ifndef KTF_KEYBOARD_H
 #define KTF_KEYBOARD_H
 
+#include <cpu.h>
 #include <drivers/pic.h>
 
 #define KEYBOARD_PORT_CMD  0x64 /* keyboard command port */
@@ -114,7 +115,7 @@ typedef enum scan_code scan_code_t;
 
 /* External Declarations */
 
-extern void init_keyboard(uint8_t dst_cpus);
+extern void init_keyboard(const cpu_t *cpu);
 extern void keyboard_interrupt_handler(void);
 extern unsigned int keyboard_process_keys(void);
 

--- a/include/drivers/pit.h
+++ b/include/drivers/pit.h
@@ -25,6 +25,7 @@
 #ifndef KTF_PIT_H
 #define KTF_PIT_H
 
+#include <cpu.h>
 #include <drivers/pic.h>
 #include <ktf.h>
 
@@ -56,7 +57,7 @@ typedef enum pit_operational_mode pit_operational_mode_t;
 
 #define PIT_BCD_MODE 1
 
-extern void init_pit(uint8_t dst_cpus);
+extern void init_pit(const cpu_t *cpu);
 extern void pit_disable(void);
 
 #endif

--- a/include/drivers/serial.h
+++ b/include/drivers/serial.h
@@ -25,6 +25,7 @@
 #ifndef KTF_DRV_SERIAL_H
 #define KTF_DRV_SERIAL_H
 
+#include <cpu.h>
 #include <drivers/pic.h>
 #include <ktf.h>
 
@@ -197,7 +198,7 @@ extern io_port_t com_ports[4];
 
 extern io_port_t get_first_com_port(void);
 extern void init_uart(uart_config_t *cfg);
-extern void init_uart_input(uint8_t dst_cpus);
+extern void init_uart_input(const cpu_t *cpu);
 extern void uart_interrupt_handler(void);
 extern int serial_putchar(io_port_t port, char c);
 extern int serial_write(io_port_t port, const char *buf, size_t len);

--- a/include/percpu.h
+++ b/include/percpu.h
@@ -42,8 +42,6 @@ struct percpu {
     char sapic_uid_str[1];
 
     apic_base_t apic_base;
-    bool enabled;
-    bool bsp;
     uint8_t family;
     uint8_t model;
     uint8_t stepping;
@@ -130,6 +128,5 @@ typedef struct percpu percpu_t;
 
 extern void init_percpu(void);
 extern percpu_t *get_percpu_page(unsigned int cpu);
-extern void for_each_percpu(void (*func)(percpu_t *percpu));
 
 #endif /* KTF_PERCPU_H */


### PR DESCRIPTION
Instead of orienting detected CPUs based on allocated percpu pages for them, use a generic and unified mechanisms to allocate and store detected CPUs metadata (including the percpu pages).

This enables better handling of the per-CPU resources and allows to easier assign tasks to specific CPUs (future commits).

This also makes the BSP identification more sane and allows to have a common API interface for finding available CPUs (and their number).