### PR TITLE
Prerequisites for the user tasks: task types, per-CPU task lists

### DIFF
--- a/common/cpu.c
+++ b/common/cpu.c
@@ -42,12 +42,14 @@ static void init_cpu(cpu_t *cpu, unsigned int id, bool is_bsp, bool enabled) {
     cpu->id = id;
     cpu->bsp = is_bsp;
     cpu->enabled = enabled;
+    cpu->scheduled = false;
     cpu->done = false;
 
     cpu->percpu = get_percpu_page(id);
     BUG_ON(!cpu->percpu);
 
     cpu->lock = SPINLOCK_INIT;
+    list_init(&cpu->task_queue);
 }
 
 cpu_t *init_cpus(void) {

--- a/common/kernel.c
+++ b/common/kernel.c
@@ -53,6 +53,7 @@ static void __noreturn echo_loop(void) {
 
 void kernel_main(void) {
     task_t *tests_task;
+    cpu_t *cpu;
 
     printk("\nKTF - Kernel Test Framework!\n");
 
@@ -63,11 +64,12 @@ void kernel_main(void) {
     }
 
     tests_task = new_kernel_task("tests", test_main, NULL);
-    schedule_task(tests_task, smp_processor_id());
+    cpu = get_bsp_cpu();
+    schedule_task(tests_task, cpu);
 
-    run_tasks(smp_processor_id());
+    run_tasks(cpu);
 
-    wait_for_all_tasks();
+    wait_for_all_cpus();
 
     printk("All tasks done.\n");
 

--- a/common/kernel.c
+++ b/common/kernel.c
@@ -31,7 +31,6 @@
 #include <percpu.h>
 #include <sched.h>
 #include <setup.h>
-#include <smp/smp.h>
 #ifdef KTF_PMU
 #include <perfmon/pfmlib.h>
 #endif
@@ -65,10 +64,11 @@ void kernel_main(void) {
 
     tests_task = new_kernel_task("tests", test_main, NULL);
     cpu = get_bsp_cpu();
+
     schedule_task(tests_task, cpu);
 
     run_tasks(cpu);
-
+    unblock_all_cpus();
     wait_for_all_cpus();
 
     printk("All tasks done.\n");

--- a/common/kernel.c
+++ b/common/kernel.c
@@ -62,7 +62,7 @@ void kernel_main(void) {
         display_multiboot_mmap();
     }
 
-    tests_task = new_task("tests", test_main, NULL);
+    tests_task = new_kernel_task("tests", test_main, NULL);
     schedule_task(tests_task, smp_processor_id());
 
     run_tasks(smp_processor_id());

--- a/common/sched.c
+++ b/common/sched.c
@@ -85,7 +85,7 @@ static task_t *create_task(void) {
 
     memset(task, 0, sizeof(*task));
     task->id = next_tid++;
-    task->gid = TASK_GROUP_UNSPECIFIED;
+    task->gid = TASK_GROUP_ALL;
     task->cpu = INVALID_CPU;
     set_task_state(task, TASK_STATE_NEW);
 
@@ -215,7 +215,7 @@ void wait_for_task_group(task_group_t group) {
 
         list_for_each_entry (task, &tasks, list) {
             /* When group is unspecified the functions waits for all tasks. */
-            if (group != TASK_GROUP_UNSPECIFIED && task->gid != group)
+            if (group != TASK_GROUP_ALL && task->gid != group)
                 continue;
 
             if (get_task_state(task) != TASK_STATE_DONE) {

--- a/common/sched.c
+++ b/common/sched.c
@@ -108,7 +108,8 @@ static void destroy_task(task_t *task) {
     kfree(task);
 }
 
-static int prepare_task(task_t *task, const char *name, task_func_t func, void *arg) {
+static int prepare_task(task_t *task, const char *name, task_func_t func, void *arg,
+                        task_type_t type) {
     if (!task)
         return -EINVAL;
 
@@ -120,6 +121,7 @@ static int prepare_task(task_t *task, const char *name, task_func_t func, void *
     task->name = name;
     task->func = func;
     task->arg = arg;
+    task->type = type;
     set_task_state(task, TASK_STATE_READY);
     return ESUCCESS;
 }
@@ -132,13 +134,13 @@ static void wait_for_task_state(task_t *task, task_state_t state) {
         cpu_relax();
 }
 
-task_t *new_task(const char *name, task_func_t func, void *arg) {
+task_t *new_task(const char *name, task_func_t func, void *arg, task_type_t type) {
     task_t *task = create_task();
 
     if (!task)
         return NULL;
 
-    if (unlikely(prepare_task(task, name, func, arg) != ESUCCESS)) {
+    if (unlikely(prepare_task(task, name, func, arg, type) != ESUCCESS)) {
         destroy_task(task);
         return NULL;
     }

--- a/drivers/acpi/acpica/osl.c
+++ b/drivers/acpi/acpica/osl.c
@@ -369,7 +369,7 @@ ACPI_STATUS AcpiOsExecute(ACPI_EXECUTE_TYPE Type, ACPI_OSD_EXEC_CALLBACK Functio
 
     cb.Function = Function;
     cb.Context = Context;
-    task = new_task(name, _osd_exec_cb_wrapper, &cb);
+    task = new_kernel_task(name, _osd_exec_cb_wrapper, &cb);
     if (!task)
         return AE_NO_MEMORY;
 

--- a/drivers/acpi/acpica/osl.c
+++ b/drivers/acpi/acpica/osl.c
@@ -374,12 +374,16 @@ ACPI_STATUS AcpiOsExecute(ACPI_EXECUTE_TYPE Type, ACPI_OSD_EXEC_CALLBACK Functio
         return AE_NO_MEMORY;
 
     set_task_group(task, TASK_GROUP_ACPI);
-    schedule_task(task, cpu->id);
+    schedule_task(task, cpu);
 
     return AE_OK;
 }
 
-void AcpiOsWaitEventsComplete(void) { wait_for_task_group(TASK_GROUP_ACPI); }
+void AcpiOsWaitEventsComplete(void) {
+    cpu_t *cpu = get_cpu(smp_processor_id());
+
+    wait_for_task_group(cpu, TASK_GROUP_ACPI);
+}
 
 /* Synchronization and locking functions */
 

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -35,11 +35,13 @@ struct cpu {
     list_head_t list;
 
     unsigned int id;
-    unsigned int bsp : 1, enabled : 1, done : 1;
+    unsigned int bsp : 1, enabled : 1, scheduled : 1, done : 1;
 
     percpu_t *percpu;
 
     spinlock_t lock;
+
+    list_head_t task_queue;
 };
 typedef struct cpu cpu_t;
 

--- a/include/sched.h
+++ b/include/sched.h
@@ -25,6 +25,7 @@
 #ifndef KTF_SCHED_H
 #define KTF_SCHED_H
 
+#include <cpu.h>
 #include <ktf.h>
 #include <lib.h>
 #include <list.h>
@@ -66,7 +67,7 @@ struct task {
     task_group_t gid;
     task_state_t state;
 
-    unsigned int cpu;
+    cpu_t *cpu;
 
     const char *name;
     task_func_t func;
@@ -79,19 +80,19 @@ typedef struct task task_t;
 /* External declarations */
 
 extern void init_tasks(void);
-extern task_t *get_task_by_id(tid_t id);
-extern task_t *get_task_by_name(const char *name);
-extern task_t *get_task_for_cpu(unsigned int cpu);
-extern void schedule_task(task_t *task, unsigned int cpu);
-extern void run_tasks(unsigned int cpu);
-extern void wait_for_task_group(task_group_t group);
+extern task_t *get_task_by_name(cpu_t *cpu, const char *name);
 extern task_t *new_task(const char *name, task_func_t func, void *arg, task_type_t type);
+extern int schedule_task(task_t *task, cpu_t *cpu);
+extern void run_tasks(cpu_t *cpu);
+extern void wait_for_task_group(const cpu_t *cpu, task_group_t group);
 
 /* Static declarations */
 
 static inline void set_task_group(task_t *task, task_group_t gid) { task->gid = gid; }
 
-static inline void wait_for_all_tasks(void) { wait_for_task_group(TASK_GROUP_ALL); }
+static inline void wait_for_cpu_tasks(cpu_t *cpu) {
+    wait_for_task_group(cpu, TASK_GROUP_ALL);
+}
 
 static inline task_t *new_kernel_task(const char *name, task_func_t func, void *arg) {
     return new_task(name, func, arg, TASK_TYPE_KERNEL);

--- a/include/sched.h
+++ b/include/sched.h
@@ -48,12 +48,21 @@ enum task_group {
 };
 typedef enum task_group task_group_t;
 
+enum task_type {
+    TASK_TYPE_KERNEL = 0,
+    TASK_TYPE_USER,
+    TASK_TYPE_INTERRUPT,
+    TASK_TYPE_ACPI_SERVICE,
+};
+typedef enum task_type task_type_t;
+
 typedef unsigned int tid_t;
 
 struct task {
     list_head_t list;
 
     tid_t id;
+    task_type_t type;
     task_group_t gid;
     task_state_t state;
 
@@ -73,15 +82,23 @@ extern void init_tasks(void);
 extern task_t *get_task_by_id(tid_t id);
 extern task_t *get_task_by_name(const char *name);
 extern task_t *get_task_for_cpu(unsigned int cpu);
-extern task_t *new_task(const char *name, task_func_t func, void *arg);
 extern void schedule_task(task_t *task, unsigned int cpu);
 extern void run_tasks(unsigned int cpu);
 extern void wait_for_task_group(task_group_t group);
+extern task_t *new_task(const char *name, task_func_t func, void *arg, task_type_t type);
 
 /* Static declarations */
 
 static inline void set_task_group(task_t *task, task_group_t gid) { task->gid = gid; }
 
 static inline void wait_for_all_tasks(void) { wait_for_task_group(TASK_GROUP_ALL); }
+
+static inline task_t *new_kernel_task(const char *name, task_func_t func, void *arg) {
+    return new_task(name, func, arg, TASK_TYPE_KERNEL);
+}
+
+static inline task_t *new_user_task(const char *name, task_func_t func, void *arg) {
+    return new_task(name, func, arg, TASK_TYPE_USER);
+}
 
 #endif /* KTF_SCHED_H */

--- a/include/sched.h
+++ b/include/sched.h
@@ -42,7 +42,7 @@ enum task_state {
 typedef enum task_state task_state_t;
 
 enum task_group {
-    TASK_GROUP_UNSPECIFIED = 0,
+    TASK_GROUP_ALL = 0,
     TASK_GROUP_ACPI,
     TASK_GROUP_TEST,
 };
@@ -82,8 +82,6 @@ extern void wait_for_task_group(task_group_t group);
 
 static inline void set_task_group(task_t *task, task_group_t gid) { task->gid = gid; }
 
-static inline void wait_for_all_tasks(void) {
-    wait_for_task_group(TASK_GROUP_UNSPECIFIED);
-}
+static inline void wait_for_all_tasks(void) { wait_for_task_group(TASK_GROUP_ALL); }
 
 #endif /* KTF_SCHED_H */

--- a/include/smp/smp.h
+++ b/include/smp/smp.h
@@ -29,8 +29,6 @@
 #include <lib.h>
 #include <processor.h>
 
-#define INVALID_CPU (~0U)
-
 /* External declarations */
 
 extern void init_smp(void);

--- a/smp/smp.c
+++ b/smp/smp.c
@@ -59,7 +59,7 @@ void __noreturn ap_startup(void) {
     ap_callin = true;
     smp_wmb();
 
-    run_tasks(cpu->id);
+    run_tasks(cpu);
 
     while (true)
         halt();


### PR DESCRIPTION
Prerequisites for the user tasks: Issue #55 

Each CPU receives its own, independent task list. That way tasks become directly assigned to a CPU and can be properly handled (scheduled and waited on) on all CPUs operating in parallel.

This PR is rebased and depends on PR #266 