### PR TITLE
Add basic support for user land address space

### DIFF
--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -161,7 +161,7 @@ void *vmap(void *va, mfn_t mfn, unsigned int order,
     mfn_t l1t_mfn, l2t_mfn, l3t_mfn;
     pgentry_t *tab, *entry;
 
-    if (!va || _ul(va) & ~PAGE_MASK)
+    if (!va || (_ul(va) & ~PAGE_ORDER_TO_MASK(order)))
         return NULL;
 
     dprintk("%s: va: %p mfn: 0x%lx (order: %u)\n", __func__, va, mfn, order);

--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -152,11 +152,11 @@ static mfn_t get_pgentry_mfn(mfn_t tab_mfn, pt_index_t index, unsigned long flag
     return mfn;
 }
 
-void *vmap(void *va, mfn_t mfn, unsigned int order,
+void *_vmap(cr3_t *cr3, void *va, mfn_t mfn, unsigned int order,
 #if defined(__x86_64__)
-           unsigned long l4_flags,
+            unsigned long l4_flags,
 #endif
-           unsigned long l3_flags, unsigned long l2_flags, unsigned long l1_flags) {
+            unsigned long l3_flags, unsigned long l2_flags, unsigned long l1_flags) {
     static spinlock_t lock = SPINLOCK_INIT;
     mfn_t l1t_mfn, l2t_mfn, l3t_mfn;
     pgentry_t *tab, *entry;
@@ -169,9 +169,9 @@ void *vmap(void *va, mfn_t mfn, unsigned int order,
     spin_lock(&lock);
 
 #if defined(__x86_64__)
-    l3t_mfn = get_pgentry_mfn(get_cr3_mfn(&cr3), l4_table_index(va), l4_flags);
+    l3t_mfn = get_pgentry_mfn(get_cr3_mfn(cr3), l4_table_index(va), l4_flags);
 #else
-    l3t_mfn = get_cr3_mfn(&cr3);
+    l3t_mfn = get_cr3_mfn(cr3);
 #endif
 
     if (order == PAGE_ORDER_1G) {
@@ -201,8 +201,14 @@ done:
     return va;
 }
 
-void vunmap(void *va, unsigned int order) {
-    vmap(va, MFN_INVALID, order, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS);
+void *vmap_kern(void *va, mfn_t mfn, unsigned int order,
+#if defined(__x86_64__)
+                unsigned long l4_flags,
+#endif
+                unsigned long l3_flags, unsigned long l2_flags, unsigned long l1_flags) {
+    unsigned long _va = _ul(va) & PAGE_ORDER_TO_MASK(order);
+
+    return _vmap(&cr3, _ptr(_va), mfn, order, l4_flags, l3_flags, l2_flags, l1_flags);
 }
 
 void init_pagetables(void) {

--- a/arch/x86/traps.c
+++ b/arch/x86/traps.c
@@ -77,7 +77,7 @@ static void init_tss(percpu_t *percpu) {
     percpu->tss.ss0 = __KERN_DS;
     percpu->tss.cr3 = _ul(cr3.reg);
 #elif defined(__x86_64__)
-    percpu->tss.rsp0 = _ul(get_free_page_top(GFP_KERNEL));
+    percpu->tss.rsp0 = _ul(get_free_page_top(GFP_KERNEL | GFP_USER));
     percpu->tss.ist[0] = _ul(get_free_page_top(GFP_KERNEL));
 #endif
     percpu->tss.iopb = sizeof(percpu->tss);
@@ -124,7 +124,7 @@ void init_traps(unsigned int cpu) {
 
     BUG_ON(!percpu);
 
-    percpu->idt = get_free_page(GFP_KERNEL);
+    percpu->idt = get_free_page(GFP_KERNEL | GFP_USER);
     BUG_ON(!percpu->idt);
 
     percpu->idt_ptr.size = (sizeof(percpu->idt) * MAX_INT) - 1;

--- a/common/setup.c
+++ b/common/setup.c
@@ -105,7 +105,7 @@ void zap_boot_mappings(void) {
                 memset(r->start, 0, r->end - r->start);
 
             for (mfn_t mfn = virt_to_mfn(r->start); mfn < virt_to_mfn(r->end); mfn++) {
-                vunmap(mfn_to_virt(mfn), PAGE_ORDER_4K);
+                vunmap_kern(mfn_to_virt(mfn), PAGE_ORDER_4K);
                 reclaim_frame(mfn, PAGE_ORDER_4K);
             }
         }

--- a/include/arch/x86/asm-macros.h
+++ b/include/arch/x86/asm-macros.h
@@ -152,6 +152,13 @@
 #endif
 .endm
 
+.macro SET_CR3 val
+    push %_ASM_AX
+    mov (\val), %_ASM_AX
+    mov %_ASM_AX, %cr3
+    pop %_ASM_AX
+.endm
+
 #define GLOBAL(name) \
     .global name;    \
 name:

--- a/include/arch/x86/page.h
+++ b/include/arch/x86/page.h
@@ -45,6 +45,8 @@
 #define MAX_PAGE_ORDER     PAGE_ORDER_1G
 #define PAGE_ORDER_INVALID (-1)
 
+#define PAGE_ORDER_TO_MASK(order) (~((PAGE_SIZE << (order)) - 1))
+
 #define _PAGE_PRESENT  0x0001
 #define _PAGE_RW       0x0002
 #define _PAGE_USER     0x0004

--- a/include/arch/x86/page.h
+++ b/include/arch/x86/page.h
@@ -159,13 +159,13 @@ typedef unsigned long mfn_t;
 
 /* External declarations */
 
-extern void *vmap(void *va, mfn_t mfn, unsigned int order,
+extern void *vmap_kern(void *va, mfn_t mfn, unsigned int order,
 #if defined(__x86_64__)
-                  unsigned long l4_flags,
+                       unsigned long l4_flags,
 #endif
-                  unsigned long l3_flags, unsigned long l2_flags, unsigned long l1_flags);
+                       unsigned long l3_flags, unsigned long l2_flags,
+                       unsigned long l1_flags);
 
-extern void vunmap(void *va, unsigned int order);
 
 extern void pat_set_type(pat_field_t field, pat_memory_type_t type);
 extern pat_memory_type_t pat_get_type(pat_field_t field);
@@ -227,68 +227,45 @@ static inline mfn_t virt_to_mfn(const void *va) {
     return paddr_to_mfn(virt_to_paddr(va));
 }
 
+static inline void vunmap_kern(void *va, unsigned int order) {
+    vmap_kern(va, MFN_INVALID, order, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS, PT_NO_FLAGS);
+}
+
 static inline void *kmap(mfn_t mfn, unsigned int order,
 #if defined(__x86_64__)
                          unsigned long l4_flags,
 #endif
                          unsigned long l3_flags, unsigned long l2_flags,
                          unsigned long l1_flags) {
-    return vmap(mfn_to_virt_kern(mfn), mfn, order,
+    return vmap_kern(mfn_to_virt_kern(mfn), mfn, order,
 #if defined(__x86_64__)
-                l4_flags,
+                     l4_flags,
 #endif
-                l3_flags, l2_flags, l1_flags);
-}
-
-static inline void *mmap(mfn_t mfn, unsigned int order,
-#if defined(__x86_64__)
-                         unsigned long l4_flags,
-#endif
-                         unsigned long l3_flags, unsigned long l2_flags,
-                         unsigned long l1_flags) {
-    return vmap(mfn_to_virt_map(mfn), mfn, order,
-#if defined(__x86_64__)
-                l4_flags,
-#endif
-                l3_flags, l2_flags, l1_flags);
+                     l3_flags, l2_flags, l1_flags);
 }
 
 static inline void *vmap_1g(void *va, mfn_t mfn, unsigned long l3_flags) {
-    return vmap(va, mfn, PAGE_ORDER_1G, L4_PROT_USER, l3_flags, PT_NO_FLAGS, PT_NO_FLAGS);
+    return vmap_kern(va, mfn, PAGE_ORDER_1G, L4_PROT, l3_flags, PT_NO_FLAGS, PT_NO_FLAGS);
 }
 
 static inline void *vmap_2m(void *va, mfn_t mfn, unsigned long l2_flags) {
-    return vmap(va, mfn, PAGE_ORDER_2M, L4_PROT_USER, L3_PROT_USER, l2_flags,
-                PT_NO_FLAGS);
+    return vmap_kern(va, mfn, PAGE_ORDER_2M, L4_PROT, L3_PROT, l2_flags, PT_NO_FLAGS);
 }
 
 static inline void *vmap_4k(void *va, mfn_t mfn, unsigned long l1_flags) {
-    return vmap(va, mfn, PAGE_ORDER_4K, L4_PROT_USER, L3_PROT_USER, L2_PROT_USER,
-                l1_flags);
+    return vmap_kern(va, mfn, PAGE_ORDER_4K, L4_PROT, L3_PROT, L2_PROT, l1_flags);
 }
 
 static inline void *kmap_1g(mfn_t mfn, unsigned long l3_flags) {
-    return kmap(mfn, PAGE_ORDER_1G, L4_PROT_USER, l3_flags, PT_NO_FLAGS, PT_NO_FLAGS);
+    return kmap(mfn, PAGE_ORDER_1G, L4_PROT, l3_flags, PT_NO_FLAGS, PT_NO_FLAGS);
 }
 
 static inline void *kmap_2m(mfn_t mfn, unsigned long l2_flags) {
-    return kmap(mfn, PAGE_ORDER_2M, L4_PROT_USER, L3_PROT_USER, l2_flags, PT_NO_FLAGS);
+    return kmap(mfn, PAGE_ORDER_2M, L4_PROT, L3_PROT, l2_flags, PT_NO_FLAGS);
 }
 
 static inline void *kmap_4k(mfn_t mfn, unsigned long l1_flags) {
-    return kmap(mfn, PAGE_ORDER_4K, L4_PROT_USER, L3_PROT_USER, L2_PROT_USER, l1_flags);
-}
-
-static inline void *mmap_1g(mfn_t mfn, unsigned long l3_flags) {
-    return mmap(mfn, PAGE_ORDER_1G, L4_PROT_USER, l3_flags, PT_NO_FLAGS, PT_NO_FLAGS);
-}
-
-static inline void *mmap_2m(mfn_t mfn, unsigned long l2_flags) {
-    return mmap(mfn, PAGE_ORDER_2M, L4_PROT_USER, L3_PROT_USER, l2_flags, PT_NO_FLAGS);
-}
-
-static inline void *mmap_4k(mfn_t mfn, unsigned long l1_flags) {
-    return mmap(mfn, PAGE_ORDER_4K, L4_PROT_USER, L3_PROT_USER, L2_PROT_USER, l1_flags);
+    return kmap(mfn, PAGE_ORDER_4K, L4_PROT, L3_PROT, L2_PROT, l1_flags);
 }
 
 #endif /* __ASSEMBLY__ */

--- a/include/arch/x86/page.h
+++ b/include/arch/x86/page.h
@@ -153,7 +153,7 @@ typedef unsigned long mfn_t;
 #define PADDR_INVALID (0UL)
 #define MFN_INVALID   (0UL)
 
-#define IS_ADDR_SPACE_VA(va, as) ((_ul(va) & (as)) == (as))
+#define IS_ADDR_SPACE_VA(va, as) (_ul(va) >= (as))
 
 /* External declarations */
 
@@ -210,6 +210,7 @@ static inline void *mfn_to_virt(mfn_t mfn) { return paddr_to_virt(mfn << PAGE_SH
 static inline paddr_t virt_to_paddr(const void *va) {
     paddr_t pa = (paddr_t) va;
 
+    /* Order matters here */
     if (IS_ADDR_SPACE_VA(va, VIRT_KERNEL_BASE))
         return pa - VIRT_KERNEL_BASE;
     if (IS_ADDR_SPACE_VA(va, VIRT_KERNEL_MAP))

--- a/include/arch/x86/pagetable.h
+++ b/include/arch/x86/pagetable.h
@@ -137,6 +137,7 @@ union cr3 {
 typedef union cr3 cr3_t;
 
 extern cr3_t cr3;
+extern cr3_t user_cr3;
 
 typedef unsigned int pt_index_t;
 

--- a/include/mm/vmm.h
+++ b/include/mm/vmm.h
@@ -55,4 +55,8 @@ static inline void *get_free_page_top(uint32_t flags) {
 
 static inline void put_page(void *page) { put_pages(page, PAGE_ORDER_4K); }
 
+static inline void put_page_top(void *page) {
+    put_pages(page - PAGE_SIZE, PAGE_ORDER_4K);
+}
+
 #endif /* KTF_VMM_H */

--- a/mm/vmm.c
+++ b/mm/vmm.c
@@ -45,19 +45,29 @@ void *get_free_pages(unsigned int order, uint32_t flags) {
     if (flags == GFP_USER) {
         va = vmap_kern(mfn_to_virt_user(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT,
                        L1_PROT);
+        vmap_user(mfn_to_virt_user(mfn), mfn, order, L4_PROT_USER, L3_PROT_USER,
+                  L2_PROT_USER, L1_PROT_USER);
     }
 
     if (flags & GFP_IDENT) {
         va = vmap_kern(mfn_to_virt(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT, L1_PROT);
+        if (flags & GFP_USER)
+            vmap_user(mfn_to_virt(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT, L1_PROT);
     }
 
     if (flags & GFP_KERNEL) {
         va = kmap(mfn, order, L4_PROT, L3_PROT, L2_PROT, L1_PROT);
+        if (flags & GFP_USER)
+            vmap_user(mfn_to_virt_kern(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT,
+                      L1_PROT);
     }
 
     if (flags & GFP_KERNEL_MAP) {
         va = vmap_kern(mfn_to_virt_map(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT,
                        L1_PROT);
+        if (flags & GFP_USER)
+            vmap_user(mfn_to_virt_map(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT,
+                      L1_PROT);
     }
 
     return va;

--- a/mm/vmm.c
+++ b/mm/vmm.c
@@ -40,24 +40,31 @@ void *get_free_pages(unsigned int order, uint32_t flags) {
 
     if (!frame)
         return NULL;
-
     mfn = frame->mfn;
 
-    if (flags & GFP_IDENT)
-        va = vmap(mfn_to_virt(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT, L1_PROT);
-    if (flags & GFP_USER)
-        va = vmap(mfn_to_virt_user(mfn), mfn, order, L4_PROT_USER, L3_PROT_USER,
-                  L2_PROT_USER, L1_PROT_USER);
-    if (flags & GFP_KERNEL)
+    if (flags == GFP_USER) {
+        va = vmap_kern(mfn_to_virt_user(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT,
+                       L1_PROT);
+    }
+
+    if (flags & GFP_IDENT) {
+        va = vmap_kern(mfn_to_virt(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT, L1_PROT);
+    }
+
+    if (flags & GFP_KERNEL) {
         va = kmap(mfn, order, L4_PROT, L3_PROT, L2_PROT, L1_PROT);
-    if (flags & GFP_KERNEL_MAP)
-        va = mmap(mfn, order, L4_PROT, L3_PROT, L2_PROT, L1_PROT);
+    }
+
+    if (flags & GFP_KERNEL_MAP) {
+        va = vmap_kern(mfn_to_virt_map(mfn), mfn, order, L4_PROT, L3_PROT, L2_PROT,
+                       L1_PROT);
+    }
 
     return va;
 }
 
 void put_pages(void *page, unsigned int order) {
     /* FIXME: unmap all mappings */
-    vunmap(page, order);
+    vunmap_kern(page, order);
     put_free_frames(virt_to_mfn(page), order);
 }


### PR DESCRIPTION
It is implementing part of the Issue #55.

Consists of the following commits:

```
    arch, pagetables: fix IS_ADDR_SPACE_VA() macro
    
    The IS_ADDR_SPACE_VA() macro was using incorrect comparison for an
    address belonging to an address space. Masking (&) could return
    incorrect result for a shifted user address space mappings.
```

```
    arch, pagetables: fix vmap()'s initial va alignment check
    
    It should check VA alignment based on requested order, not just
    PAGE_MASK (4K pages order).
```

```
    arch, pagetables: prepare vmap() to handle separate address spaces
    
    Make _vmap() accept CR3 as parameter, indicating which address space
    is being mapped into. And turn vmap() and vunmap() into helper functions
    with default address space of the kernel (vmap_kern(), vunmap_kern()).
    
    Remove mmap_*() helper functions as they are confusing and not used.
```

```
    mm/vmm: add put_page_top() helper function for stack pages
```

```
    arch, pagetables: add user address space
    
    Add separate CR3 variable holding top of the user space page tables.
    Add vmap_user*() helper functions, capable of mapping both kernel
    mappings (kernel privilege, for necessary kernel mappings in user
    address space) and user mappings (userland data and code).
    
    Map userland data and code to both kernel and user address spaces.
    
    Map IDT and TSS's RSP0 stack to user address space as kernel mappings.
```

```
    arch: add SET_CR3 assembly macro
    
    The macro preserves RAX register via stack, but does not clean the stack.
```