### PR TITLE
sched: add task repetition functionality

### DIFF
--- a/include/sched.h
+++ b/include/sched.h
@@ -59,6 +59,11 @@ typedef enum task_type task_type_t;
 
 typedef unsigned int tid_t;
 
+typedef enum task_repeat {
+    TASK_REPEAT_LOOP = 0,
+    TASK_REPEAT_ONCE = 1,
+} task_repeat_t;
+
 struct task {
     list_head_t list;
 
@@ -66,6 +71,8 @@ struct task {
     task_type_t type;
     task_group_t gid;
     task_state_t state;
+    task_repeat_t repeat;
+    atomic64_t exec_count;
 
     cpu_t *cpu;
     void *stack;
@@ -110,4 +117,18 @@ static inline void execute_tasks(void) {
     run_tasks(get_bsp_cpu());
     wait_for_all_cpus();
 }
+
+static inline void set_task_repeat(task_t *task, task_repeat_t value) {
+    ASSERT(task);
+    task->repeat = value;
+}
+
+static inline void set_task_loop(task_t *task) {
+    set_task_repeat(task, TASK_REPEAT_LOOP);
+}
+
+static inline void set_task_once(task_t *task) {
+    set_task_repeat(task, TASK_REPEAT_ONCE);
+}
+
 #endif /* KTF_SCHED_H */

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -169,6 +169,7 @@ int unit_tests(void *_unused) {
     task_user1 = new_user_task("test1 user", test_user_task_func1, NULL);
     task_user2 = new_user_task("test2 user", test_user_task_func2, NULL);
 
+    set_task_repeat(task1, 10);
     schedule_task(task1, get_bsp_cpu());
     schedule_task(task2, get_cpu(1));
     schedule_task(task_user1, get_bsp_cpu());


### PR DESCRIPTION
By default tasks run once and get destroyed. It might be useful to run them in an infinite loop (task done -> task scheduled -> ...) in order to achieve tasks interleaving (multiple tasks scheduled on the same CPU).
It might be also useful to set an arbitrary value of repetitions for a given task.

This commit adds simple set_task_repeat() and set_task_loop() API to allow task repetitions.

Example use:
```
task_t *task1, *task2;

task1 = new_user_task("task1", func1, NULL);
task2 = new_kernel_task("task2", func2, NULL);

set_task_repeat(task1, 2); // Or: set_task_loop(task1);
schedule_task(task1, get_cpu(1));

set_task_repeat(task2, 2); // Or: set_task_loop(task2);
schedule_task(task2, get_cpu(1));
```