### PR TITLE
Automatically generate structure member offsets for assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ Makeconf.local
 .DS_Store
 *.swp
 *.xz
+asm-offsets.s
+asm-offsets.h
 grub/boot/grub
 drivers/acpi/acpica/source/
 third-party/libpfm/COPYING

--- a/arch/x86/asm-offsets.c
+++ b/arch/x86/asm-offsets.c
@@ -33,4 +33,38 @@
 
 void __asm_offset_header(void) {
     OFFSETOF(usermode_private, percpu_t, usermode_private);
+
+    OFFSETOF(cpu_exc_error_code, cpu_exc_t, error_code);
+    OFFSETOF(cpu_exc_vector, cpu_exc_t, vector);
+    OFFSETOF(cpu_exc_ip, cpu_exc_t, _ASM_IP);
+    OFFSETOF(cpu_exc_cs, cpu_exc_t, cs);
+    OFFSETOF(cpu_exc_flags, cpu_exc_t, _ASM_FLAGS);
+    OFFSETOF(cpu_exc_sp, cpu_exc_t, _ASM_SP);
+    OFFSETOF(cpu_exc_ss, cpu_exc_t, ss);
+
+    OFFSETOF(cpu_regs_ax, cpu_regs_t, _ASM_AX);
+    OFFSETOF(cpu_regs_bx, cpu_regs_t, _ASM_BX);
+    OFFSETOF(cpu_regs_cx, cpu_regs_t, _ASM_CX);
+    OFFSETOF(cpu_regs_dx, cpu_regs_t, _ASM_DX);
+    OFFSETOF(cpu_regs_si, cpu_regs_t, _ASM_SI);
+    OFFSETOF(cpu_regs_di, cpu_regs_t, _ASM_DI);
+    OFFSETOF(cpu_regs_bp, cpu_regs_t, _ASM_BP);
+#if defined(__x86_64__)
+    OFFSETOF(cpu_regs_r8, cpu_regs_t, r8);
+    OFFSETOF(cpu_regs_r9, cpu_regs_t, r9);
+    OFFSETOF(cpu_regs_r10, cpu_regs_t, r10);
+    OFFSETOF(cpu_regs_r11, cpu_regs_t, r11);
+    OFFSETOF(cpu_regs_r12, cpu_regs_t, r12);
+    OFFSETOF(cpu_regs_r13, cpu_regs_t, r13);
+    OFFSETOF(cpu_regs_r14, cpu_regs_t, r14);
+    OFFSETOF(cpu_regs_r15, cpu_regs_t, r15);
+#endif
+
+    OFFSETOF(cpu_regs_error_code, cpu_regs_t, exc.error_code);
+    OFFSETOF(cpu_regs_vector, cpu_regs_t, exc.vector);
+    OFFSETOF(cpu_regs_ip, cpu_regs_t, exc._ASM_IP);
+    OFFSETOF(cpu_regs_cs, cpu_regs_t, exc.cs);
+    OFFSETOF(cpu_regs_flags, cpu_regs_t, exc._ASM_FLAGS);
+    OFFSETOF(cpu_regs_sp, cpu_regs_t, exc._ASM_SP);
+    OFFSETOF(cpu_regs_ss, cpu_regs_t, exc.ss);
 }

--- a/arch/x86/asm-offsets.c
+++ b/arch/x86/asm-offsets.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2023 Open Source Security, Inc.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <compiler.h>
+#include <percpu.h>
+
+#define EMIT_DEFINE(s, v)                                                                \
+    asm volatile(".ascii \"@@#define " #s " %0 /* " #v " */@@\"\n" ::"i"(v))
+#define OFFSETOF(__symbol, __type, __member)                                             \
+    EMIT_DEFINE(__symbol, offsetof(__type, __member));
+
+void __asm_offset_header(void) {
+    OFFSETOF(usermode_private, percpu_t, usermode_private);
+}

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -24,6 +24,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include <asm-macros.h>
+#include <asm-offsets.h>
 #include <processor.h>
 #include <segment.h>
 #include <page.h>
@@ -129,14 +130,14 @@ ENTRY(enter_usermode)
     PUSHF
 
     /* Save stack pointer onto per-cpu */
-    mov %_ASM_SP, %gs:(%_ASM_DX)
+    mov %_ASM_SP, %gs:usermode_private
 
     /* Move to user stack */
-    mov %_ASM_CX, %_ASM_SP
+    mov %_ASM_DX, %_ASM_SP
 
     /* SS + SP */
     push $__USER_DS
-    push %_ASM_CX
+    push %_ASM_DX
 
     /* EFLAGS */
     PUSHF

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -31,7 +31,7 @@
 #include <traps.h>
 
 .macro _handle_usermode cr3
-    testb $0x3, 8(%_ASM_SP)
+    testb $0x3, cpu_exc_cs(%_ASM_SP)
     jz 1f /* skip if from kernel mode */
         SET_CR3 \cr3
         swapgs
@@ -54,7 +54,7 @@ ENTRY(entry_\sym)
         push $0
     .endif
 
-    movl $\vec, 0x4(%_ASM_SP)
+    movl $\vec, cpu_exc_vector(%_ASM_SP)
     jmp handle_exception
 END_FUNC(entry_\sym)
 .endm

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -23,8 +23,8 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <asm-macros.h>
 #include <asm-offsets.h>
+#include <asm-macros.h>
 #include <processor.h>
 #include <segment.h>
 #include <page.h>
@@ -38,17 +38,17 @@
     1:
 .endm
 
-.macro from_usermode
+.macro enter_from_usermode
     _handle_usermode cr3
 .endm
 
-.macro to_usermode
+.macro enter_to_usermode
     _handle_usermode user_cr3
 .endm
 
 .macro exception_handler sym vec has_error_code
 ENTRY(entry_\sym)
-    from_usermode
+    enter_from_usermode
 
     .if \has_error_code == 0
         push $0
@@ -61,14 +61,14 @@ END_FUNC(entry_\sym)
 
 .macro interrupt_handler sym func
 ENTRY(asm_interrupt_handler_\sym)
-    from_usermode
+    enter_from_usermode
 
     cld
     SAVE_ALL_REGS
     call \func
     RESTORE_ALL_REGS
 
-    to_usermode
+    enter_to_usermode
     IRET
 END_FUNC(asm_interrupt_handler_\sym)
 .endm
@@ -111,7 +111,7 @@ ENTRY(handle_exception)
     add $4, %_ASM_SP
 #endif
 
-    to_usermode
+    enter_to_usermode
     IRET
 END_FUNC(handle_exception)
 
@@ -145,10 +145,10 @@ ENTRY(enter_usermode)
     orl $X86_EFLAGS_IOPL, (%_ASM_SP)
 
     /* CS + IP */
-    pushq $__USER_CS
+    push $__USER_CS
     push $usermode_stub
 
-    to_usermode
+    enter_to_usermode
     IRET
 END_FUNC(enter_usermode)
 

--- a/arch/x86/traps.c
+++ b/arch/x86/traps.c
@@ -299,7 +299,7 @@ static bool extables_fixup(struct cpu_regs *regs) {
 void do_exception(struct cpu_regs *regs) {
     static char ec_str[32], panic_str[128];
 
-    if (!from_usermode(regs->cs) && extables_fixup(regs))
+    if (!enter_from_usermode(regs->cs) && extables_fixup(regs))
         return;
 
     dump_regs(regs);
@@ -314,7 +314,7 @@ void do_exception(struct cpu_regs *regs) {
              regs->_ASM_SP);
 
     /* Handle user tasks' exceptions */
-    if (from_usermode(regs->cs)) {
+    if (enter_from_usermode(regs->cs)) {
         printk("Task exception: %s\n", panic_str);
         goto_syscall_exit(-EFAULT);
     }

--- a/common/sched.c
+++ b/common/sched.c
@@ -204,8 +204,7 @@ static void run_task(task_t *task) {
 
     set_task_state(task, TASK_STATE_RUNNING);
     if (task->type == TASK_TYPE_USER)
-        task->result = enter_usermode(task->func, task->arg,
-                                      PERCPU_OFFSET(usermode_private), task->stack);
+        task->result = enter_usermode(task->func, task->arg, task->stack);
     else
         task->result = task->func(task->arg);
     set_task_state(task, TASK_STATE_DONE);

--- a/include/arch/x86/processor.h
+++ b/include/arch/x86/processor.h
@@ -241,6 +241,20 @@ typedef uint64_t x86_reg_t;
 typedef uint32_t x86_reg_t;
 #endif
 
+struct cpu_exc {
+    x86_ex_error_code_t error_code;
+    /* Populated by exception entry */
+    uint32_t vector;
+
+    /* Hardware exception */
+    x86_reg_t _ASM_IP;
+    uint16_t cs, _pad_cs[3];
+    x86_reg_t _ASM_FLAGS;
+    x86_reg_t _ASM_SP;
+    uint16_t ss, _pad_ss[3];
+} __packed;
+typedef struct cpu_exc cpu_exc_t;
+
 struct cpu_regs {
     x86_reg_t r15;
     x86_reg_t r14;
@@ -258,17 +272,8 @@ struct cpu_regs {
     x86_reg_t _ASM_BX;
     x86_reg_t _ASM_AX;
 
-    x86_ex_error_code_t error_code;
-    /* Populated by exception entry */
-    uint32_t vector;
-
-    /* Hardware exception */
-    x86_reg_t _ASM_IP;
-    uint16_t cs, _pad_cs[3];
-    x86_reg_t _ASM_FLAGS;
-    x86_reg_t _ASM_SP;
-    uint16_t ss, _pad_ss[3];
-};
+    cpu_exc_t exc;
+} __packed;
 typedef struct cpu_regs cpu_regs_t;
 
 union msr_star {

--- a/include/usermode.h
+++ b/include/usermode.h
@@ -36,8 +36,8 @@
 
 /* Static declarations */
 
-static inline bool from_usermode(uint16_t cs) {
-    return (cs & 0x3) != 0;
+static inline bool enter_from_usermode(uint16_t cs) {
+    return (cs & 0x3) == 0x3;
 }
 
 static inline void goto_syscall_exit(long exit_code) {

--- a/include/usermode.h
+++ b/include/usermode.h
@@ -47,8 +47,7 @@ static inline void goto_syscall_exit(long exit_code) {
 
 /* External declarations */
 
-extern unsigned long enter_usermode(task_func_t fn, void *fn_arg,
-                                    unsigned long usermode_private, void *user_stack);
+extern unsigned long enter_usermode(task_func_t fn, void *fn_arg, void *user_stack);
 extern void __naked syscall_handler(void);
 
 extern void init_usermode(percpu_t *percpu);

--- a/tools/asm-offsets/asm-offsets.sh
+++ b/tools/asm-offsets/asm-offsets.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+INPUT=$1
+OUTPUT=$2
+
+cat <<EOT > "$OUTPUT"
+/* This file has been automatically generated from $INPUT. */
+
+#ifndef KTF_ASM_OFFSETS_H
+#define KTF_ASM_OFFSETS_H
+
+$(awk -F '@@' '/\.ascii "@@/ {print $2}' "$INPUT" | tr -d '$')
+
+#endif /* KTF_ASM_OFFSETS_H */
+EOT


### PR DESCRIPTION
Generate offsets of selected structure members to be used in assembly files.
    
The asm-offsets.c file is compiled into assembly (.s) file and parsed by asm-offsets.sh script to generate the final include header asm-offsets.h.
    
This is needed to be able to access per-cpu variables in assembly.
