### PR TITLE
pagetable enhancements

### DIFF
--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -36,7 +36,7 @@ cr3_t user_cr3;
 static inline const char *dump_pte_flags(char *buf, size_t size, pte_t pte) {
     /* clang-format off */
     snprintf(buf, size, "%c %c%c%c%c%c%c%c%c%c",
-        pte.NX  ? 'X' : '-',
+        pte.NX  ? '-' : 'X',
         pte.G   ? 'G' : '-',
         pte.PAT ? 'p' : '-',
         pte.D   ? 'D' : '-',

--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -90,16 +90,14 @@ static inline void dump_page_table(void *table, int level) {
     }
 }
 
-void dump_pagetables(void) {
+void dump_pagetables(cr3_t cr3) {
     printk("\nPage Tables:\n");
 
     /* Map all used frames to be able to parse page tables */
     map_used_memory();
 
-    paddr_t cur_cr3 = read_cr3();
-
-    printk("CR3: paddr: 0x%lx\n", cur_cr3);
-    dump_page_table(paddr_to_virt_kern(cur_cr3), 4);
+    printk("CR3: paddr: 0x%lx\n", cr3.paddr);
+    dump_page_table(paddr_to_virt_kern(cr3.paddr), 4);
 }
 
 static void *init_map_mfn(mfn_t mfn) {

--- a/common/setup.c
+++ b/common/setup.c
@@ -208,7 +208,7 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic, unsigned long
 
     WRITE_SP(get_free_pages_top(PAGE_ORDER_2M, GFP_KERNEL));
     if (opt_debug)
-        dump_pagetables();
+        dump_pagetables(cr3);
 
     if (setup_framebuffer())
         display_banner();

--- a/include/arch/x86/pagetable.h
+++ b/include/arch/x86/pagetable.h
@@ -288,7 +288,7 @@ extern pml4_t l4_pt_entries[L4_PT_ENTRIES];
 #endif
 
 extern void init_pagetables(void);
-extern void dump_pagetables(void);
+extern void dump_pagetables(cr3_t cr3);
 
 #endif /* __ASSEMBLY__ */
 


### PR DESCRIPTION
I needed to debug an issue with user mode mappings, which resulted in the following patches. 

It's useful to see what mappings usermode has. To do this, dump_pagetables takes a cr3_t type argument, which can be for example be user_cr3. 

I think executable should show `X` instead of the vice-versa.. But that's just an opinion, so we can drop this.