### PR TITLE
Improve syscall implementation

### DIFF
--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -29,6 +29,7 @@
 #include <segment.h>
 #include <page.h>
 #include <traps.h>
+#include <usermode.h>
 
 .macro _handle_usermode cr3
     testb $0x3, cpu_exc_cs(%_ASM_SP)
@@ -163,7 +164,7 @@ ENTRY(usermode_stub)
 
     /* sys_exit */
     mov %_ASM_AX, %_ASM_DI
-    xor %_ASM_AX, %_ASM_AX
+    mov $SYSCALL_EXIT, %_ASM_AX
     syscall
 END_FUNC(usermode_stub)
 

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -48,6 +48,18 @@
     _handle_usermode user_cr3
 .endm
 
+.macro syscall_from_usermode
+    SET_CR3 cr3
+    swapgs
+    SWITCH_STACK
+.endm
+
+.macro syscall_to_usermode
+    SWITCH_STACK
+    swapgs
+    SET_CR3 user_cr3
+.endm
+
 .macro exception_handler sym vec has_error_code
 ENTRY(entry_\sym)
     enter_from_usermode
@@ -154,6 +166,16 @@ ENTRY(enter_usermode)
     IRET
 END_FUNC(enter_usermode)
 
+ENTRY(syscall_exit)
+    POPF
+
+    /* Save exit code to return value register (AX) */
+    mov %_ASM_SI, cpu_regs_ax(%_ASM_SP)
+    RESTORE_ALL_REGS
+
+    ret
+END_FUNC(syscall_exit)
+
 ENTRY(terminate_user_task)
     SWITCH_STACK
     POPF
@@ -163,6 +185,29 @@ ENTRY(terminate_user_task)
 
     ret
 END_FUNC(terminate_user_task)
+
+.align PAGE_SIZE
+ENTRY(syscall_handler_entry)
+    SAVE_CALLEE_SAVED_REGS
+    syscall_from_usermode
+
+    cmp $SYSCALL_EXIT, %_ASM_AX
+    jz syscall_exit
+
+    push %_ASM_CX
+    push %r11
+
+    mov %_ASM_DI, %_ASM_CX
+    mov %_ASM_AX, %_ASM_DI
+    call syscall_handler
+
+    pop %r11
+    pop %_ASM_CX
+
+    syscall_to_usermode
+    RESTORE_CALLEE_SAVED_REGS
+    SYSRET
+END_FUNC(syscall_handler_entry)
 
 SECTION(.text.user, "ax", 16)
 ENTRY(usermode_stub)

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -68,7 +68,12 @@ ENTRY(entry_\sym)
         push $0
     .endif
 
+#if defined(__x86_64__)
     movl $\vec, cpu_exc_vector(%_ASM_SP)
+#else
+    push $\vec
+#endif
+
     jmp handle_exception
 END_FUNC(entry_\sym)
 .endm
@@ -119,11 +124,7 @@ ENTRY(handle_exception)
 
     RESTORE_ALL_REGS
 
-#if defined(__x86_64__)
     add $8, %_ASM_SP
-#else
-    add $4, %_ASM_SP
-#endif
 
     enter_to_usermode
     IRET

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -30,6 +30,7 @@
 #include <page.h>
 #include <traps.h>
 #include <usermode.h>
+#include <errno.h>
 
 .macro _handle_usermode cr3
     testb $0x3, cpu_exc_cs(%_ASM_SP)
@@ -152,6 +153,16 @@ ENTRY(enter_usermode)
     enter_to_usermode
     IRET
 END_FUNC(enter_usermode)
+
+ENTRY(terminate_user_task)
+    SWITCH_STACK
+    POPF
+
+    movl $-EFAULT, cpu_regs_ax(%_ASM_SP)
+    RESTORE_ALL_REGS
+
+    ret
+END_FUNC(terminate_user_task)
 
 SECTION(.text.user, "ax", 16)
 ENTRY(usermode_stub)

--- a/arch/x86/traps.c
+++ b/arch/x86/traps.c
@@ -43,6 +43,8 @@ extern void asm_interrupt_handler_uart(void);
 extern void asm_interrupt_handler_keyboard(void);
 extern void asm_interrupt_handler_timer(void);
 
+extern void terminate_user_task(void);
+
 static void init_tss(percpu_t *percpu) {
 #if defined(__i386__)
     percpu->tss_df.iopb = sizeof(percpu->tss_df);
@@ -316,7 +318,7 @@ void do_exception(struct cpu_regs *regs) {
     /* Handle user tasks' exceptions */
     if (enter_from_usermode(regs->exc.cs)) {
         printk("Task exception: %s\n", panic_str);
-        goto_syscall_exit(-EFAULT);
+        terminate_user_task();
     }
 
     panic(panic_str);

--- a/common/console.c
+++ b/common/console.c
@@ -41,7 +41,7 @@
 static console_callback_entry_t console_callbacks[2];
 static unsigned int num_console_callbacks;
 
-static void vprintk(const char *fmt, va_list args) {
+void vprintk(const char *fmt, va_list args) {
     static char buf[VPRINTK_BUF_SIZE];
     static spinlock_t lock = SPINLOCK_INIT;
     unsigned int i;

--- a/include/arch/x86/asm-macros.h
+++ b/include/arch/x86/asm-macros.h
@@ -272,55 +272,31 @@ name ## _end:
     "pop %%" STR(_ASM_AX) "\n"
 
 #if defined(__x86_64__)
-#define SAVE_CLOBBERED_REGS64() \
-    asm volatile (              \
-        "push %%r8\n"           \
-        "push %%r9\n"           \
-        "push %%r10\n"          \
-        "push %%r11\n"          \
-        "push %%r12\n"          \
-        "push %%r13\n"          \
-        "push %%r14\n"          \
-        "push %%r15\n"          \
-    ::: "memory")
+#define SAVE_CALLEE_SAVED_REGS64() \
+    "push %%r12\n" \
+    "push %%r13\n" \
+    "push %%r14\n" \
+    "push %%r15\n"
 
-#define RESTORE_CLOBBERED_REGS64() \
-    asm volatile (                 \
-        "pop %%" STR(r15) "\n"     \
-        "pop %%" STR(r14) "\n"     \
-        "pop %%" STR(r13) "\n"     \
-        "pop %%" STR(r12) "\n"     \
-        "pop %%" STR(r11) "\n"     \
-        "pop %%" STR(r10) "\n"     \
-        "pop %%" STR(r9) "\n"      \
-        "pop %%" STR(r8) "\n"      \
-    ::: "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15")
+#define RESTORE_CALLEE_SAVED_REGS64() \
+    "pop %%r15\n" \
+    "pop %%r14\n" \
+    "pop %%r13\n" \
+    "pop %%r12\n"
 #else
-#define SAVE_CLOBBERED_REGS64()
-#define RESTORE_CLOBBERED_REGS64()
+#define SAVE_CALLEE_SAVED_REGS64()
+#define RESTORE_CALLEE_SAVED_REGS64()
 #endif
 
-#define SAVE_CLOBBERED_REGS()       \
-    asm volatile (                  \
-        "push %%" STR(_ASM_CX) "\n" \
-        "push %%" STR(_ASM_DX) "\n" \
-        "push %%" STR(_ASM_SI) "\n" \
-        "push %%" STR(_ASM_DI) "\n" \
-        "push %%" STR(_ASM_BP) "\n" \
-    ::: "memory");                  \
-    SAVE_CLOBBERED_REGS64()
+#define SAVE_CALLEE_SAVED_REGS() \
+    "push %%" STR(_ASM_BX) "\n"  \
+    "push %%" STR(_ASM_BP) "\n"  \
+    SAVE_CALLEE_SAVED_REGS64()
 
-#define RESTORE_CLOBBERED_REGS()    \
-    RESTORE_CLOBBERED_REGS64();     \
-    asm volatile (                  \
-        "pop %%" STR(_ASM_BP) "\n"  \
-        "pop %%" STR(_ASM_DI) "\n"  \
-        "pop %%" STR(_ASM_SI) "\n"  \
-        "pop %%" STR(_ASM_DX) "\n"  \
-        "pop %%" STR(_ASM_CX) "\n"  \
-    ::: STR(_ASM_BP), STR(_ASM_DI), \
-    STR(_ASM_SI), STR(_ASM_DX), STR(_ASM_CX))
-/* clang-format on */
+#define RESTORE_CALLEE_SAVED_REGS() \
+    RESTORE_CALLEE_SAVED_REGS64()   \
+    "pop %%" STR(_ASM_BP) "\n"      \
+    "pop %%" STR(_ASM_BX) "\n"
 
 #if defined(__x86_64__)
 #define POPF() "popfq\n"

--- a/include/arch/x86/asm-macros.h
+++ b/include/arch/x86/asm-macros.h
@@ -228,8 +228,8 @@ name ## _end:
 /* clang-format off */
 #if defined(__x86_64__)
 #define SAVE_ALL_REGS64() \
-    "push %%r8\n" \
-    "push %%r9\n" \
+    "push %%r8\n"  \
+    "push %%r9\n"  \
     "push %%r10\n" \
     "push %%r11\n" \
     "push %%r12\n" \
@@ -238,14 +238,14 @@ name ## _end:
     "push %%r15\n"
 
 #define RESTORE_ALL_REGS64() \
-    "pop %%" STR(r15) "\n" \
-    "pop %%" STR(r14) "\n" \
-    "pop %%" STR(r13) "\n" \
-    "pop %%" STR(r12) "\n" \
-    "pop %%" STR(r11) "\n" \
-    "pop %%" STR(r10) "\n" \
-    "pop %%" STR(r9) "\n" \
-    "pop %%" STR(r8) "\n"
+    "pop %%r15\n" \
+    "pop %%r14\n" \
+    "pop %%r13\n" \
+    "pop %%r12\n" \
+    "pop %%r11\n" \
+    "pop %%r10\n" \
+    "pop %%r9\n"  \
+    "pop %%r8\n"
 #else
 #define SAVE_ALL_REGS64()
 #define RESTORE_ALL_REGS64()

--- a/include/arch/x86/asm-macros.h
+++ b/include/arch/x86/asm-macros.h
@@ -162,11 +162,23 @@
 #endif
 .endm
 
+.macro SYSRET
+#if defined(__x86_64__)
+    sysretq
+#else
+    sysret
+#endif
+.endm
+
 .macro SET_CR3 val
     push %_ASM_AX
     mov (\val), %_ASM_AX
     mov %_ASM_AX, %cr3
     pop %_ASM_AX
+.endm
+
+.macro SWITCH_STACK
+    xchg %_ASM_SP, %gs:usermode_private
 .endm
 
 #define GLOBAL(name) \

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -148,4 +148,10 @@ typedef uint64_t off_t;
 
 #define __always_inline __inline __attribute__((always_inline))
 
+#define USTR(str)                                                                        \
+    ({                                                                                   \
+        static char _str[] __user_data = str;                                            \
+        _str;                                                                            \
+    })
+
 #endif /* KTF_COMPILER_H */

--- a/include/console.h
+++ b/include/console.h
@@ -35,6 +35,7 @@ struct console_callback_entry {
 };
 typedef struct console_callback_entry console_callback_entry_t;
 
+extern void vprintk(const char *fmt, va_list args);
 extern void printk(const char *fmt, ...);
 
 #define dprintk(fmt, ...)                                                                \

--- a/include/lib.h
+++ b/include/lib.h
@@ -332,10 +332,6 @@ static inline void swapgs(void) {
     asm volatile("swapgs");
 }
 
-static inline void syscall(void) {
-    asm volatile("syscall");
-}
-
 static inline void sysret(void) {
 #if defined(__i386__)
     asm volatile("sysret");

--- a/include/usermode.h
+++ b/include/usermode.h
@@ -43,13 +43,12 @@ static inline bool enter_from_usermode(uint16_t cs) {
 /* External declarations */
 
 extern unsigned long enter_usermode(task_func_t fn, void *fn_arg, void *user_stack);
-extern void __naked syscall_handler(void);
+extern void syscall_handler_entry(void);
 
 extern void init_usermode(percpu_t *percpu);
 
 extern void __user_text exit(unsigned long exit_code);
-extern void __user_text printf(const char *fmt, unsigned long arg1, unsigned long arg2,
-                               unsigned long arg3);
+extern void __user_text printf(const char *fmt, ...);
 extern void *__user_text mmap(void *va, unsigned long order);
 extern void __user_text munmap(void *va, unsigned long order);
 

--- a/include/usermode.h
+++ b/include/usermode.h
@@ -40,11 +40,6 @@ static inline bool enter_from_usermode(uint16_t cs) {
     return (cs & 0x3) == 0x3;
 }
 
-static inline void goto_syscall_exit(long exit_code) {
-    swapgs();
-    asm volatile("jmp syscall_handler" ::"A"(SYSCALL_EXIT), "D"(exit_code));
-}
-
 /* External declarations */
 
 extern unsigned long enter_usermode(task_func_t fn, void *fn_arg, void *user_stack);

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -72,21 +72,19 @@ static unsigned long test_kernel_task_func(void *arg) {
 }
 
 static unsigned long __user_text test_user_task_func1(void *arg) {
-    static char *fmt_printf __user_data = "printf: %u %x %d\n";
 
-    printf(fmt_printf, 1234, 0x41414141, 9);
-    printf(fmt_printf, 1235, 0x42424242, -9);
+    printf(USTR("printf: %u %x %d\n"), 1234, 0x41414141, 9);
+    printf(USTR("printf: %u %x %d\n"), 1235, 0x42424242, -9);
 
     exit(9);
     return 0;
 }
 
 static unsigned long __user_text test_user_task_func2(void *arg) {
-    static char *fmt_mmap __user_data = "mmap: %lx\n";
     void *va;
 
     va = mmap(_ptr(0xfff80000), PAGE_ORDER_4K);
-    printf(fmt_mmap, _ul(va), 0, 0);
+    printf(USTR("mmap: %lx\n"), _ul(va));
 
     memset(va, 0xcc, 0x1000);
     ((void (*)(void)) va)();


### PR DESCRIPTION
Note: This PR is based on #282. Please review and merge #282 first or focus only on the new bits.

    Main change is a split of the syscall implementation with proper
    assembly routines: syscall_handler_entry() and simplified
    syscall_exit() and a simplified C-level syscall handler function.
    The syscall_exit() is implemented and handled fully in asm.
    
    The syscall() usermode function implements typical syscall ABI,
    passing syscall number via AX register and the rest of parameters
    via SI, DX, DI, R8 and R9. The assembly entry point rearranges the
    registers to fix the C-level handler function API.
    Only 5 arguments to the syscall can be provided.
    Usermode upon calling syscall() takes are of callee saved registers by
    saving/restoring them via usermode stack (only reminder of unused
    registers is preserved as the rest is considered implicitely clobbered).
    
    Additionally SYSCALL_PRINTF has been improved to support variadic
    number of arguments (it passes the va_list args to the kernel mode).

