### PR TITLE
Improved framebuffer text scrolling mechanism

### DIFF
--- a/common/cmdline.c
+++ b/common/cmdline.c
@@ -70,6 +70,9 @@ string_cmd("com3", opt_com3);
 static char opt_com4[20];
 string_cmd("com4", opt_com4);
 
+bool opt_fb_scroll = true;
+bool_cmd("fb_scroll", opt_fb_scroll);
+
 const char *kernel_cmdline;
 
 void __text_init cmdline_parse(const char *cmdline) {

--- a/drivers/fb/fb.c
+++ b/drivers/fb/fb.c
@@ -191,6 +191,11 @@ void fb_write(void *fb_addr, const char *buf, size_t len, uint32_t color) {
             col = 0;
         }
 
+        if (c == '\r') {
+            col = 0;
+            continue;
+        }
+
         if (c == '\n')
             continue;
 

--- a/include/cmdline.h
+++ b/include/cmdline.h
@@ -67,6 +67,7 @@ extern bool opt_hpet;
 extern bool opt_fpu;
 extern bool opt_qemu_console;
 extern bool opt_poweroff;
+extern bool opt_fb_scroll;
 
 extern const char *kernel_cmdline;
 

--- a/include/drivers/fb.h
+++ b/include/drivers/fb.h
@@ -36,5 +36,6 @@ extern void draw_line(uint32_t x1, uint32_t y1, uint32_t x2, uint32_t y2, uint32
 extern void draw_logo(void);
 extern void fb_write(void *fb_addr, const char *buf, size_t len, uint32_t color);
 extern bool setup_framebuffer(void);
+extern void set_fb_scroll(bool state);
 
 #endif /* KTF_DRV_FB_H */


### PR DESCRIPTION
Instead of clearing screen and starting over (losing previously displayed text), use one line scrolling.