### PR TITLE
Further fixes for usermode handling

### DIFF
--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -145,10 +145,9 @@ ENTRY(enter_usermode)
     PUSHF
 
     /* Save stack pointer onto per-cpu */
-    mov %_ASM_SP, %gs:usermode_private
+    mov %_ASM_DX, %gs:(usermode_private)
 
-    /* Move to user stack */
-    mov %_ASM_DX, %_ASM_SP
+    syscall_to_usermode
 
     /* SS + SP */
     push $__USER_DS
@@ -162,8 +161,6 @@ ENTRY(enter_usermode)
     /* CS + IP */
     push $__USER_CS
     push $usermode_stub
-
-    enter_to_usermode
     IRET
 END_FUNC(enter_usermode)
 

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -92,6 +92,21 @@ ENTRY(asm_interrupt_handler_\sym)
 END_FUNC(asm_interrupt_handler_\sym)
 .endm
 
+ENTRY(handle_exception)
+    cld
+    SAVE_ALL_REGS
+
+    mov %_ASM_SP, %_ASM_DI
+    call do_exception
+
+    RESTORE_ALL_REGS
+
+    add $8, %_ASM_SP
+
+    enter_to_usermode
+    IRET
+END_FUNC(handle_exception)
+
 exception_handler DE  X86_EX_DE  0
 exception_handler DB  X86_EX_DB  0
 exception_handler NMI X86_EX_NMI 0
@@ -115,27 +130,32 @@ exception_handler XM  X86_EX_XM  0
 exception_handler VE  X86_EX_VE  0
 exception_handler SE  X86_EX_SE  1
 
-ENTRY(handle_exception)
-    cld
-    SAVE_ALL_REGS
-
-    mov %_ASM_SP, %_ASM_DI
-    call do_exception
-
-    RESTORE_ALL_REGS
-
-    add $8, %_ASM_SP
-
-    enter_to_usermode
-    IRET
-END_FUNC(handle_exception)
-
 interrupt_handler timer timer_interrupt_handler
 interrupt_handler uart uart_interrupt_handler
 interrupt_handler keyboard keyboard_interrupt_handler
 #ifdef KTF_ACPICA
 interrupt_handler acpi acpi_interrupt_handler
 #endif
+
+ENTRY(syscall_exit)
+    POPF
+
+    /* Save exit code to return value register (AX) */
+    mov %_ASM_SI, cpu_regs_ax(%_ASM_SP)
+    RESTORE_ALL_REGS
+
+    ret
+END_FUNC(syscall_exit)
+
+ENTRY(terminate_user_task)
+    SWITCH_STACK
+    POPF
+
+    movl $-EFAULT, cpu_regs_ax(%_ASM_SP)
+    RESTORE_ALL_REGS
+
+    ret
+END_FUNC(terminate_user_task)
 
 ENTRY(enter_usermode)
     /* FIXME: Add 32-bit support */
@@ -163,26 +183,6 @@ ENTRY(enter_usermode)
     push $usermode_stub
     IRET
 END_FUNC(enter_usermode)
-
-ENTRY(syscall_exit)
-    POPF
-
-    /* Save exit code to return value register (AX) */
-    mov %_ASM_SI, cpu_regs_ax(%_ASM_SP)
-    RESTORE_ALL_REGS
-
-    ret
-END_FUNC(syscall_exit)
-
-ENTRY(terminate_user_task)
-    SWITCH_STACK
-    POPF
-
-    movl $-EFAULT, cpu_regs_ax(%_ASM_SP)
-    RESTORE_ALL_REGS
-
-    ret
-END_FUNC(terminate_user_task)
 
 .align PAGE_SIZE
 ENTRY(syscall_handler_entry)

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -107,6 +107,8 @@ ENTRY(handle_exception)
     IRET
 END_FUNC(handle_exception)
 
+.align PAGE_SIZE
+GLOBAL(exception_handlers)
 exception_handler DE  X86_EX_DE  0
 exception_handler DB  X86_EX_DB  0
 exception_handler NMI X86_EX_NMI 0
@@ -129,14 +131,18 @@ exception_handler MC  X86_EX_MC  0
 exception_handler XM  X86_EX_XM  0
 exception_handler VE  X86_EX_VE  0
 exception_handler SE  X86_EX_SE  1
+GLOBAL(end_exception_handlers)
 
+GLOBAL(interrupt_handlers)
 interrupt_handler timer timer_interrupt_handler
 interrupt_handler uart uart_interrupt_handler
 interrupt_handler keyboard keyboard_interrupt_handler
 #ifdef KTF_ACPICA
 interrupt_handler acpi acpi_interrupt_handler
 #endif
+GLOBAL(end_interrupt_handlers)
 
+.align PAGE_SIZE
 ENTRY(syscall_exit)
     POPF
 
@@ -157,6 +163,8 @@ ENTRY(terminate_user_task)
     ret
 END_FUNC(terminate_user_task)
 
+.align PAGE_SIZE
+GLOBAL(usermode_helpers)
 ENTRY(enter_usermode)
     /* FIXME: Add 32-bit support */
 
@@ -184,7 +192,6 @@ ENTRY(enter_usermode)
     IRET
 END_FUNC(enter_usermode)
 
-.align PAGE_SIZE
 ENTRY(syscall_handler_entry)
     SAVE_CALLEE_SAVED_REGS
     syscall_from_usermode
@@ -206,6 +213,7 @@ ENTRY(syscall_handler_entry)
     RESTORE_CALLEE_SAVED_REGS
     SYSRET
 END_FUNC(syscall_handler_entry)
+GLOBAL(end_usermode_helpers)
 
 SECTION(.text.user, "ax", 16)
 ENTRY(usermode_stub)

--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -30,7 +30,7 @@
 #include <spinlock.h>
 #include <string.h>
 
-cr3_t cr3;
+cr3_t __aligned(PAGE_SIZE) cr3;
 cr3_t user_cr3;
 
 static inline const char *dump_pte_flags(char *buf, size_t size, pte_t pte) {


### PR DESCRIPTION
This PR is based on #284. Please review the #284 first and rebase this one to limit the changes.
Only top 3 commits differ.

```
    arch,entry,usermode: fix user pagetable mappings alignment
    
    The exception handlers as well as interrupt handlers need to be
    properly mapped into user pagetables. Add global symbols to find their
    addresses and align the beginning on a page boundary.
    
    Similar entry_usermode() and syscall_handler_entry() need to be aligned
    and ideally share the same page.
    
    The syscall_exit() and similar routines do not need user pagetable
    mappings.
    
    Add also an explicit mapping for user_cr3 variable.
```    
```
    arch,entry: cleanup: rearrange code
    
    Signed-off-by: Pawel Wieczorkiewicz <wipawel@grsecurity.net>
```
```
    arch,usermode: fix user stack handling in enter_usermode()
    
    We need to preserve user stack address on percpu first, to use allow
    simple stack switching.
    
    We need to switch to user pagetables before putting IRET frame onto
    user stack.
    
    Signed-off-by: Pawel Wieczorkiewicz <wipawel@grsecurity.net>
```