### PR TITLE
ctags and better python support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ endif
 LD := ld
 
 NM := nm
-PYTHON := python
+PYTHON := $(shell tools/ci/get-python.sh)
 SHELL := bash
 RM := rm
 LN := ln

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ endif
 LD := ld
 
 NM := nm
+CTAGS := ctags
 PYTHON := $(shell tools/ci/get-python.sh)
 SHELL := bash
 RM := rm
@@ -230,6 +231,7 @@ clean:
 	$(VERBOSE) find $(KTF_ROOT) -name \*.img -delete
 	$(VERBOSE) find $(KTF_ROOT) -name \*.xz -delete
 	$(VERBOSE) find $(KTF_ROOT) -name cscope.\* -delete
+	$(VERBOSE) find $(KTF_ROOT) -maxdepth 1 \( -name tags -or -name TAGS \) -delete
 	$(VERBOSE) find $(KTF_ROOT) -name $(ASM_OFFSETS_S) -delete
 	$(VERBOSE) find $(KTF_ROOT) -name $(ASM_OFFSETS_H) -delete
 	$(VERBOSE) find $(PFMLIB_DIR) -mindepth 1 ! -name $(PFMLIB_NAME)-$(PFMLIB_VER).tar.gz -delete
@@ -314,6 +316,10 @@ cscope:
 	@echo "CSCOPE"
 	$(VERBOSE) $(all_sources) > cscope.files
 	$(VERBOSE) cscope -b -q -k
+
+tags TAGS: $(SOURCES) $(HEADERS) $(ASM_SOURCES)
+	@echo "TAGS ($@)"
+	$(VERBOSE) $(CTAGS) -o $@ $+
 
 .PHONY: style
 style:

--- a/tools/ci/get-python.sh
+++ b/tools/ci/get-python.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Not all systems ship a 'python' wrapper, try version specific ones if we
+# fail to find the version-agnostic one.
+#
+# Copyright (c) 2023 Open Source Security, Inc.
+
+try_python() {
+	if $1 -c 'exit' 2>/dev/null; then
+		echo "$1"
+		exit 0
+	fi
+}
+
+try_python python
+try_python python3
+try_python python2
+
+echo "error: python interpreter not found!" >&2
+exit 1


### PR DESCRIPTION
- Try to find a working python interpreter automatically, as not all systems ship the version-agnostic `pyton` one any more.
- Also `tags` and `TAGS` make targets for ctags support.

These simplify my developer life on Debian 12 ;)