### PR TITLE
CI: Add testing for CLang

### DIFF
--- a/.github/workflows/c-cpp-clang.yml
+++ b/.github/workflows/c-cpp-clang.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: C/C++ CI (CLang)
 
 on:
   push:
@@ -15,5 +15,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: make clean
       run: make clean
-    - name: make all
-      run: make all
+    - name: make CC=clang all
+      run: make CC=clang all

--- a/.github/workflows/c-cpp-gcc.yml
+++ b/.github/workflows/c-cpp-gcc.yml
@@ -1,0 +1,19 @@
+name: C/C++ CI (GCC)
+
+on:
+  push:
+    branches: [ mainline ]
+  pull_request:
+    branches: [ mainline ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make clean
+      run: make clean
+    - name: make CC=gcc all
+      run: make CC=gcc all

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -15,9 +15,13 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential qemu qemu-user
+        sudo apt-get install -y build-essential clang qemu qemu-user
     - uses: actions/checkout@v2
-    - name: Build the Docker image
-      run: ./tools/ci/build-docker.sh
-    - name: Run the Docker image
-      run: ./tools/ci/launch-test.sh
+    - name: Build the Docker image (GCC)
+      run: ./tools/ci/build-docker.sh gcc
+    - name: Run the Docker image (GCC)
+      run: ./tools/ci/launch-test.sh gcc
+    - name: Build the Docker image (CLang)
+      run: ./tools/ci/build-docker.sh clang
+    - name: Run the Docker image (CLang)
+      run: ./tools/ci/launch-test.sh clang

--- a/drivers/acpi/acpica/acktf.h
+++ b/drivers/acpi/acpica/acktf.h
@@ -68,6 +68,10 @@
 #define ACPI_INIT_FUNCTION
 #define ACPI_CACHE_T ACPI_MEMORY_LIST
 
+#define ACPI_UINTPTR_T     uintptr_t
+#define ACPI_TO_INTEGER(p) ((uintptr_t)(p))
+#define ACPI_OFFSET(d, f)  offsetof(d, f)
+
 /* Host-dependent types and defines for in-kernel ACPICA */
 
 #define ACPI_EXPORT_SYMBOL(symbol)

--- a/tools/ci/build-docker.sh
+++ b/tools/ci/build-docker.sh
@@ -5,6 +5,8 @@
 # This script builds the project's boot.iso file in the docker environment
 set -e
 
+COMPILER=$1
+
 # Execute relative to this script
 SCRIPTDIR="$( cd "$(dirname "$0")" ; pwd -P )"
 declare -r SCRIPTDIR
@@ -14,4 +16,4 @@ cd "$SCRIPTDIR"/../..
 
 # Build project in docker
 make clean V=1
-make docker:boot.iso V=1
+make docker:boot.iso V=1 CC=$COMPILER

--- a/tools/ci/launch-test.sh
+++ b/tools/ci/launch-test.sh
@@ -6,6 +6,8 @@
 # next launches a test and checks for a successful timeout.
 set -e
 
+COMPILER=$1
+
 # Execute relative to this script
 SCRIPTDIR="$( cd "$(dirname "$0")" ; pwd -P )"
 declare -r SCRIPTDIR
@@ -16,12 +18,12 @@ cd "$SCRIPTDIR"/../..
 # Build project in docker
 echo "Building project from scratch"
 make clean V=1
-make UNITTEST=1 docker:boot.iso V=1
+make UNITTEST=1 docker:boot.iso V=1 CC=$COMPILER
 
 # Use QEMU to launch the guest
 echo "Launching KTF"
 declare -i STATUS=0
-timeout 10 make UNITTEST=1 docker:boot V=1 || STATUS=$?
+timeout 10 make UNITTEST=1 docker:boot V=1 CC=$COMPILER || STATUS=$?
 
 # Check if the expected exit code happened (124 for timeout)
 if [ "$STATUS" -ne 0 ] && [ "$STATUS" -ne 124 ]

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 # build dependencies
 RUN apt-get update -y
-RUN apt-get install -y build-essential make xorriso qemu-utils qemu qemu-system-x86 patch
+RUN apt-get install -y build-essential clang make xorriso qemu-utils qemu qemu-system-x86 patch
 # grub is a bit special in containers
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install grub2 kmod python3
 


### PR DESCRIPTION
Add C/C++ workflow to build with clang and make the current one use gcc explicitly.

Docker workflow does two runs with different builds:
1. with gcc
2. with clang