### PR TITLE
Fix interrupts handling

### DIFF
--- a/arch/x86/asm-offsets.c
+++ b/arch/x86/asm-offsets.c
@@ -34,13 +34,19 @@
 void __asm_offset_header(void) {
     OFFSETOF(usermode_private, percpu_t, usermode_private);
 
+    OFFSETOF(cpu_irq_ip, cpu_irq_t, _ASM_IP);
+    OFFSETOF(cpu_irq_cs, cpu_irq_t, cs);
+    OFFSETOF(cpu_irq_flags, cpu_irq_t, _ASM_FLAGS);
+    OFFSETOF(cpu_irq_sp, cpu_irq_t, _ASM_SP);
+    OFFSETOF(cpu_irq_ss, cpu_irq_t, ss);
+
     OFFSETOF(cpu_exc_error_code, cpu_exc_t, error_code);
     OFFSETOF(cpu_exc_vector, cpu_exc_t, vector);
-    OFFSETOF(cpu_exc_ip, cpu_exc_t, _ASM_IP);
-    OFFSETOF(cpu_exc_cs, cpu_exc_t, cs);
-    OFFSETOF(cpu_exc_flags, cpu_exc_t, _ASM_FLAGS);
-    OFFSETOF(cpu_exc_sp, cpu_exc_t, _ASM_SP);
-    OFFSETOF(cpu_exc_ss, cpu_exc_t, ss);
+    OFFSETOF(cpu_exc_ip, cpu_exc_t, irq._ASM_IP);
+    OFFSETOF(cpu_exc_cs, cpu_exc_t, irq.cs);
+    OFFSETOF(cpu_exc_flags, cpu_exc_t, irq._ASM_FLAGS);
+    OFFSETOF(cpu_exc_sp, cpu_exc_t, irq._ASM_SP);
+    OFFSETOF(cpu_exc_ss, cpu_exc_t, irq.ss);
 
     OFFSETOF(cpu_regs_ax, cpu_regs_t, _ASM_AX);
     OFFSETOF(cpu_regs_bx, cpu_regs_t, _ASM_BX);
@@ -62,9 +68,9 @@ void __asm_offset_header(void) {
 
     OFFSETOF(cpu_regs_error_code, cpu_regs_t, exc.error_code);
     OFFSETOF(cpu_regs_vector, cpu_regs_t, exc.vector);
-    OFFSETOF(cpu_regs_ip, cpu_regs_t, exc._ASM_IP);
-    OFFSETOF(cpu_regs_cs, cpu_regs_t, exc.cs);
-    OFFSETOF(cpu_regs_flags, cpu_regs_t, exc._ASM_FLAGS);
-    OFFSETOF(cpu_regs_sp, cpu_regs_t, exc._ASM_SP);
-    OFFSETOF(cpu_regs_ss, cpu_regs_t, exc.ss);
+    OFFSETOF(cpu_regs_ip, cpu_regs_t, exc.irq._ASM_IP);
+    OFFSETOF(cpu_regs_cs, cpu_regs_t, exc.irq.cs);
+    OFFSETOF(cpu_regs_flags, cpu_regs_t, exc.irq._ASM_FLAGS);
+    OFFSETOF(cpu_regs_sp, cpu_regs_t, exc.irq._ASM_SP);
+    OFFSETOF(cpu_regs_ss, cpu_regs_t, exc.irq.ss);
 }

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -67,6 +67,29 @@
 .macro syscall_to_usermode
     _to_usermode
 .endm
+
+.macro irq_from_usermode
+    testb $0x3, cpu_irq_cs(%_ASM_SP)
+    jz 1f /* skip if from kernel mode */
+        _from_usermode
+        /* Preserve USER CS and a fake RIP on kernel stack */
+        /* This is expected by the irq_to_usermode         */
+        push $__USER_CS
+        push $0
+    1:
+.endm
+
+.macro irq_to_usermode
+    testb $0x3, cpu_irq_cs(%_ASM_SP)
+    jz 1f /* skip if from kernel mode */
+        /* Clean up USER CS and a fake RIP from kernel stack */
+#if defined(__x86_64__)
+        add $16, %_ASM_SP
+#else
+        add $8, %_ASM_SP
+#endif
+        _to_usermode
+    1:
 .endm
 
 .macro exception_handler sym vec has_error_code
@@ -94,8 +117,7 @@ END_FUNC(entry_\sym)
 
 .macro interrupt_handler sym func
 ENTRY(asm_interrupt_handler_\sym)
-    _from_usermode
-
+    irq_from_usermode
     MASK_USER_FLAGS
 
     cld
@@ -103,7 +125,7 @@ ENTRY(asm_interrupt_handler_\sym)
     call \func
     RESTORE_ALL_REGS
 
-    _to_usermode
+    irq_to_usermode
     IRET
 END_FUNC(asm_interrupt_handler_\sym)
 .endm

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -32,38 +32,45 @@
 #include <usermode.h>
 #include <errno.h>
 
-.macro _handle_usermode cr3
-    testb $0x3, cpu_exc_cs(%_ASM_SP)
-    jz 1f /* skip if from kernel mode */
-        SET_CR3 \cr3
-        swapgs
-    1:
-.endm
-
-.macro enter_from_usermode
-    _handle_usermode cr3
-.endm
-
-.macro enter_to_usermode
-    _handle_usermode user_cr3
-.endm
-
-.macro syscall_from_usermode
+.macro _from_usermode
     SET_CR3 cr3
     swapgs
     SWITCH_STACK
 .endm
 
-.macro syscall_to_usermode
+.macro _to_usermode
     SWITCH_STACK
     swapgs
     SET_CR3 user_cr3
 .endm
 
+.macro exc_from_usermode
+    testb $0x3, cpu_exc_cs(%_ASM_SP)
+    jz 1f /* skip if from kernel mode */
+        SET_CR3 cr3
+        swapgs
+    1:
+.endm
+
+.macro exc_to_usermode
+    testb $0x3, cpu_exc_cs(%_ASM_SP)
+    jz 1f /* skip if from kernel mode */
+        swapgs
+        SET_CR3 user_cr3
+    1:
+.endm
+
+.macro syscall_from_usermode
+    _from_usermode
+.endm
+
+.macro syscall_to_usermode
+    _to_usermode
+.endm
+.endm
+
 .macro exception_handler sym vec has_error_code
 ENTRY(entry_\sym)
-    enter_from_usermode
-
     .if \has_error_code == 0
         push $0
     .endif
@@ -74,6 +81,7 @@ ENTRY(entry_\sym)
     push $\vec
 #endif
 
+    exc_from_usermode
     jmp handle_exception
 END_FUNC(entry_\sym)
 .endm
@@ -86,7 +94,7 @@ END_FUNC(entry_\sym)
 
 .macro interrupt_handler sym func
 ENTRY(asm_interrupt_handler_\sym)
-    enter_from_usermode
+    _from_usermode
 
     MASK_USER_FLAGS
 
@@ -95,7 +103,7 @@ ENTRY(asm_interrupt_handler_\sym)
     call \func
     RESTORE_ALL_REGS
 
-    enter_to_usermode
+    _to_usermode
     IRET
 END_FUNC(asm_interrupt_handler_\sym)
 .endm
@@ -109,9 +117,8 @@ ENTRY(handle_exception)
 
     RESTORE_ALL_REGS
 
+    exc_to_usermode
     add $8, %_ASM_SP
-
-    enter_to_usermode
     IRET
 END_FUNC(handle_exception)
 
@@ -184,7 +191,7 @@ ENTRY(enter_usermode)
     mov %_ASM_DX, %gs:(usermode_private)
 
     /* Now switch stack and address space */
-    syscall_to_usermode
+    _to_usermode
 
     /* SS + SP */
     push $__USER_DS

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -32,6 +32,12 @@
 #include <usermode.h>
 #include <errno.h>
 
+.macro MASK_USER_FLAGS
+    PUSHF
+    andl $~(USERMODE_FLAGS_MASK), (%_ASM_SP)
+    POPF
+.endm
+
 .macro _from_usermode
     SET_CR3 cr3
     swapgs
@@ -47,6 +53,7 @@
 .macro exc_from_usermode
     testb $0x3, cpu_exc_cs(%_ASM_SP)
     jz 1f /* skip if from kernel mode */
+        MASK_USER_FLAGS
         SET_CR3 cr3
         swapgs
     1:
@@ -71,6 +78,7 @@
 .macro irq_from_usermode
     testb $0x3, cpu_irq_cs(%_ASM_SP)
     jz 1f /* skip if from kernel mode */
+        MASK_USER_FLAGS
         _from_usermode
         /* Preserve USER CS and a fake RIP on kernel stack */
         /* This is expected by the irq_to_usermode         */
@@ -109,16 +117,9 @@ ENTRY(entry_\sym)
 END_FUNC(entry_\sym)
 .endm
 
-.macro MASK_USER_FLAGS
-    PUSHF
-    andl $~(USERMODE_FLAGS_MASK), (%_ASM_SP)
-    POPF
-.endm
-
 .macro interrupt_handler sym func
 ENTRY(asm_interrupt_handler_\sym)
     irq_from_usermode
-    MASK_USER_FLAGS
 
     cld
     SAVE_ALL_REGS

--- a/common/setup.c
+++ b/common/setup.c
@@ -227,9 +227,6 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic, unsigned long
 
     init_tasks();
 
-    /* Initialize timers */
-    init_timers(bsp);
-
     /* Try to initialize ACPI (and MADT) */
 #ifndef KTF_ACPICA
     if (init_acpi() < 0) {
@@ -241,10 +238,13 @@ void __noreturn __text_init kernel_start(uint32_t multiboot_magic, unsigned long
             boot_flags.nosmp = true;
     }
 
+    init_ioapic();
+
+    /* Initialize timers */
+    init_timers(bsp);
+
     if (!boot_flags.nosmp)
         init_smp();
-
-    init_ioapic();
 
     init_pci();
 

--- a/grub/grub-test.cfg
+++ b/grub/grub-test.cfg
@@ -10,6 +10,6 @@ terminal_input --append serial
 terminal_output --append serial
 
 menuentry "kernel64" {
-   multiboot2 /boot/kernel64.bin.xz poweroff=1 com1=0x3f8,115200,8,n,1      integer=42   boolean=1   string=foo badstring=toolong booleantwo tests=unit_tests
+   multiboot2 /boot/kernel64.bin.xz poweroff=1 com1=0x3f8,115200,8,n,1 pit=1 hpet=1 apic_timer=1     integer=42   boolean=1   string=foo badstring=toolong booleantwo tests=unit_tests
    boot
 }

--- a/include/arch/x86/processor.h
+++ b/include/arch/x86/processor.h
@@ -245,17 +245,28 @@ typedef uint64_t x86_reg_t;
 typedef uint32_t x86_reg_t;
 #endif
 
-struct cpu_exc {
-    x86_ex_error_code_t error_code;
-    /* Populated by exception entry */
-    uint32_t vector;
-
+struct cpu_irq {
     /* Hardware exception */
     x86_reg_t _ASM_IP;
     uint16_t cs, _pad_cs[3];
     x86_reg_t _ASM_FLAGS;
     x86_reg_t _ASM_SP;
     uint16_t ss, _pad_ss[3];
+} __packed;
+typedef struct cpu_irq cpu_irq_t;
+
+struct cpu_exc {
+    union {
+        struct {
+            x86_ex_error_code_t error_code;
+            /* Populated by exception entry */
+            uint32_t vector;
+        };
+        /* We stuff the vector number into the upper 32 bit of the error code */
+        uint64_t _raw;
+    };
+
+    cpu_irq_t irq;
 } __packed;
 typedef struct cpu_exc cpu_exc_t;
 


### PR DESCRIPTION
Up to now the interrupts for timers and keyboard were completely broken - especially when happen in usermode.
This series attempts to toss out most obvious bugs and does some cleanup.