### PR TITLE
entry: SAVE/RESTORE_ALL_REGS cond. exclude AX

### DIFF
--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -202,7 +202,7 @@ ENTRY(enter_usermode)
 END_FUNC(enter_usermode)
 
 ENTRY(syscall_handler_entry)
-    SAVE_ALL_REGS
+    SAVE_ALL_REGS include_ax=0
     syscall_from_usermode
 
     cmp $SYSCALL_EXIT, %_ASM_AX
@@ -219,12 +219,12 @@ ENTRY(syscall_handler_entry)
     pop %_ASM_CX
 
     syscall_to_usermode
-    RESTORE_ALL_REGS
+    RESTORE_ALL_REGS include_ax=0
     SYSRET
 END_FUNC(syscall_handler_entry)
 
 ENTRY(sysenter_handler_entry)
-    SAVE_ALL_REGS
+    SAVE_ALL_REGS include_ax=0
     syscall_from_usermode
 
     MASK_USER_FLAGS
@@ -238,13 +238,13 @@ ENTRY(sysenter_handler_entry)
     call syscall_handler
 
     syscall_to_usermode
-    RESTORE_ALL_REGS
+    RESTORE_ALL_REGS include_ax=0
 
     SYSEXIT
 END_FUNC(sysenter_handler_entry)
 
 ENTRY(int80_handler_entry)
-    SAVE_ALL_REGS
+    SAVE_ALL_REGS include_ax=0
     syscall_from_usermode
 
     MASK_USER_FLAGS
@@ -257,7 +257,7 @@ ENTRY(int80_handler_entry)
     call syscall_handler
 
     syscall_to_usermode
-    RESTORE_ALL_REGS
+    RESTORE_ALL_REGS include_ax=0
     IRET
 END_FUNC(int80_handler_entry)
 GLOBAL(end_usermode_helpers)

--- a/include/arch/x86/asm-macros.h
+++ b/include/arch/x86/asm-macros.h
@@ -88,8 +88,10 @@
     pop %eax
 .endm
 
-.macro SAVE_ALL_REGS
+.macro SAVE_ALL_REGS include_ax=1
+    .if \include_ax
     push %_ASM_AX
+    .endif
     push %_ASM_BX
     push %_ASM_CX
     push %_ASM_DX
@@ -108,7 +110,7 @@
 #endif
 .endm
 
-.macro RESTORE_ALL_REGS
+.macro RESTORE_ALL_REGS include_ax=1
 #if defined(__x86_64__)
     pop %r15
     pop %r14
@@ -125,7 +127,9 @@
     pop %_ASM_DX
     pop %_ASM_CX
     pop %_ASM_BX
+    .if \include_ax
     pop %_ASM_AX
+    .endif
 .endm
 
 .macro SAVE_CALLEE_SAVED_REGS


### PR DESCRIPTION
Because syscalls provides the result in ax, we probably don't want to restore it to its original value. Allow to conditionally exclude ax.