### PR TITLE
entry: disable interrupts during usermode transition

### DIFF
--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -196,6 +196,9 @@ ENTRY(enter_usermode)
     SAVE_ALL_REGS
     PUSHF
 
+    /* Disable interrupts for stack switch and swapgs */
+    cli
+
     /* Save user stack pointer onto per-cpu */
     mov %_ASM_DX, %gs:(usermode_private)
 
@@ -208,8 +211,8 @@ ENTRY(enter_usermode)
 
     /* EFLAGS */
     PUSHF
-
-    orl $X86_EFLAGS_IOPL, (%_ASM_SP)
+    /* Set IOPL=3 and re-enable interrupts via IRET */
+    orl $(X86_EFLAGS_IOPL | X86_EFLAGS_IF), (%_ASM_SP)
 
     /* CS + IP */
     push $__USER_CS

--- a/arch/x86/entry.S
+++ b/arch/x86/entry.S
@@ -175,6 +175,10 @@ ENTRY(syscall_exit)
     SWITCH_STACK
     POPF
 
+    /* Restore default GS (PERCPU) segment selector */
+    mov $__KERN_PERCPU, %_ASM_AX
+    mov %_ASM_AX, %gs
+
     /* Save exit code to return value register (AX) */
     mov %_ASM_SI, cpu_regs_ax(%_ASM_SP)
     RESTORE_ALL_REGS

--- a/arch/x86/traps.c
+++ b/arch/x86/traps.c
@@ -114,7 +114,7 @@ static void init_gdt(percpu_t *percpu) {
     lgdt(&percpu->gdt_ptr);
 
     write_ss(__KERN_DS);
-    write_gs(GDT_PERCPU << 3);
+    write_gs(__KERN_PERCPU);
     wrmsr(MSR_KERNEL_GS_BASE, 0x0);
 
     init_tss(percpu);

--- a/include/arch/x86/segment.h
+++ b/include/arch/x86/segment.h
@@ -136,6 +136,8 @@
 #define __USER_DS __USER_DS64
 #endif
 
+#define __KERN_PERCPU (GDT_PERCPU << 3)
+
 #define _GDT_ENTRY(flags, base, limit)                                                   \
     ((((base) &_U64(0xff000000)) << (56 - 24)) | (((flags) &_U64(0x0000f0ff)) << 40) |   \
      (((limit) &_U64(0x000f0000)) << (48 - 16)) | (((base) &_U64(0x00ffffff)) << 16) |   \


### PR DESCRIPTION
SWAPGS instruction used to switch the GS base to usermode one (currently 0x0) for PERCPU variables accesses is only stable within an uninterruptable context.
Disable interrupts before the stack switch in enter_usermode() and re-enable it via IRET long return.