### PR TITLE
dump_pagetables: Avoid incorrect BUG_ON condition.

### DIFF
--- a/arch/x86/pagetables.c
+++ b/arch/x86/pagetables.c
@@ -101,6 +101,9 @@ static inline bool is_canon_va(const void *va) {
 static void dump_pagetable(mfn_t table, int level) {
     pte_t *pt;
 
+    if (level == 0)
+        return;
+
     BUG_ON(mfn_invalid(table));
     pt = tmp_map_mfn(table);
     BUG_ON(!pt);

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -189,6 +189,8 @@ int unit_tests(void *_unused) {
     cpu_freq_expect("Prototyp Amazing Foo One @ 1GHz", 1000000000);
     cpu_freq_expect("Prototyp Amazing Foo Two @ 1.00GHz", 1000000000);
 
+    dump_pagetables(&cr3);
+
     map_pagetables(&cr3, NULL);
     map_pagetables(&cr3, &user_cr3);
     pte_t *pte = get_pte(unit_tests);


### PR DESCRIPTION
The recursion should stop at level 0, since at this level table is not a page table anymore. This would otherwise trigger a panic when dumping page tables.