### PR TITLE
Reserve multiboot physical memory

### DIFF
--- a/arch/x86/boot/multiboot.c
+++ b/arch/x86/boot/multiboot.c
@@ -182,6 +182,15 @@ void init_multiboot(unsigned long *addr, const char **cmdline) {
     }
 }
 
+bool mbi_reserved_range(addr_range_t *reserved_range) {
+    if (multiboot2_hdr == NULL)
+        return false;
+
+    reserved_range->start = multiboot2_hdr;
+    reserved_range->end = _ptr(_ul(multiboot2_hdr) + multiboot2_hdr_size);
+    return true;
+}
+
 void map_multiboot_areas(void) {
     paddr_t mbi_start = _paddr(multiboot2_hdr);
     vmap_range(mbi_start, multiboot2_hdr_size, L1_PROT_RO, VMAP_KERNEL | VMAP_IDENT);

--- a/include/mm/regions.h
+++ b/include/mm/regions.h
@@ -89,6 +89,7 @@ extern int get_memory_range(paddr_t pa, addr_range_t *r);
 
 extern int get_avail_memory_range(unsigned index, addr_range_t *r);
 extern bool has_memory_range(paddr_t pa);
+extern bool in_reserved_range(paddr_t pa, size_t size);
 
 extern void init_regions(void);
 

--- a/include/multiboot.h
+++ b/include/multiboot.h
@@ -297,6 +297,7 @@ extern unsigned mbi_get_avail_memory_ranges_num(void);
 extern int mbi_get_avail_memory_range(unsigned index, addr_range_t *r);
 extern int mbi_get_memory_range(paddr_t pa, addr_range_t *r);
 extern bool mbi_has_framebuffer(void);
+extern bool mbi_reserved_range(addr_range_t *reserved_range);
 #endif /* __ASSEMBLY__ */
 
 #endif /* KTF_MULTIBOOT_H */

--- a/include/multiboot2.h
+++ b/include/multiboot2.h
@@ -433,6 +433,7 @@ extern void map_multiboot_areas(void);
 extern unsigned mbi_get_avail_memory_ranges_num(void);
 extern int mbi_get_avail_memory_range(unsigned index, addr_range_t *r);
 extern int mbi_get_memory_range(paddr_t pa, addr_range_t *r);
+extern bool mbi_reserved_range(addr_range_t *reserved_range);
 
 #endif /* __ASSEMBLY__ */
 


### PR DESCRIPTION
Fixes #342 by passing the multiboot memory range to the physical memory manager. The physical memory manager then skips any memory overlapping with the multiboot memory range.