### PR TITLE
Fix pmm deadlock

### DIFF
--- a/include/arch/x86/pagetable.h
+++ b/include/arch/x86/pagetable.h
@@ -178,6 +178,9 @@ extern void *vmap_2m(cr3_t *cr3_ptr, void *va, mfn_t mfn, unsigned long l2_flags
                      bool propagate_user);
 extern void *vmap_4k(cr3_t *cr3_ptr, void *va, mfn_t mfn, unsigned long l1_flags,
                      bool propagate_user);
+/* this function may only be called while already holding the vmap_lock */
+extern void *vmap_4k_nolock(cr3_t *cr3_ptr, void *va, mfn_t mfn, unsigned long l1_flags,
+                            bool propagate_user);
 
 extern int vunmap_kern(void *va, mfn_t *mfn, unsigned int *order);
 extern int vunmap_user(void *va, mfn_t *mfn, unsigned int *order);
@@ -358,6 +361,11 @@ static inline void *vmap_kern_2m(void *va, mfn_t mfn, unsigned long l2_flags) {
 
 static inline void *vmap_kern_4k(void *va, mfn_t mfn, unsigned long l1_flags) {
     return vmap_4k(&cr3, va, mfn, l1_flags, false);
+}
+
+/* Same as vmap_kern_4k but does not take vmap_lock. Callers must hold vmap_lock! */
+static inline void *vmap_kern_4k_nolock(void *va, mfn_t mfn, unsigned long l1_flags) {
+    return vmap_4k_nolock(&cr3, va, mfn, l1_flags, false);
 }
 
 static inline void *vmap_user(void *va, mfn_t mfn, unsigned int order,

--- a/include/mm/pmm.h
+++ b/include/mm/pmm.h
@@ -73,6 +73,7 @@ extern void init_pmm(void);
 
 extern frame_t *get_free_frames_cond(free_frames_cond_t cb);
 extern frame_t *get_free_frames(unsigned int order);
+extern frame_t *get_free_frame_norefill(void);
 extern void put_free_frames(mfn_t mfn, unsigned int order);
 extern void reclaim_frame(mfn_t mfn, unsigned int order);
 
@@ -84,6 +85,7 @@ extern frame_t *find_busy_paddr_frame(paddr_t paddr);
 extern frame_t *find_paddr_frame(paddr_t paddr);
 
 extern void map_frames_array(void);
+extern void refill_from_paging(void);
 
 /* Static definitions */
 

--- a/mm/pmm.c
+++ b/mm/pmm.c
@@ -95,6 +95,7 @@ static inline void init_frames_array(frames_array_t *array) {
     for (unsigned i = 0; i < ARRAY_SIZE(array->frames); i++)
         init_frame(&array->frames[i]);
     list_add(&array->list, &frames);
+    total_free_frames += array->meta.free_count;
 }
 
 static frames_array_t *new_frames_array(void) {
@@ -117,7 +118,6 @@ static frames_array_t *new_frames_array(void) {
 
     init_frames_array(array);
 
-    total_free_frames += array->meta.free_count;
     return array;
 error:
     panic("PMM: Unable to allocate new page for frame array");


### PR DESCRIPTION
An ugly first attempt to allow pmm frame array refill without deadlocking.

Intended to fix #343 