### PR TITLE
Disable static array-bounds check so suppress false positives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,9 @@ CFLAGS  += -fno-stack-protector -fno-exceptions -fno-builtin -fomit-frame-pointe
 CFLAGS  += -mcmodel=kernel -fno-pic -fno-asynchronous-unwind-tables -fno-unwind-tables
 CFLAGS  += -Wno-unused-parameter -Wno-address-of-packed-member
 CFLAGS  += -Werror
+# Newer versions of GCC warn about memory accesses at non-zero offsets from null pointers.
+# As we use this intentionally at different places in our code, these warnings result in many false positives.
+CFLAGS  += -Wno-array-bounds
 
 ifneq ($(V), 1)
 VERBOSE=@


### PR DESCRIPTION
Newer versions of GCC warn about memory accesses at non-zero offsets from null pointers. As we use this intentionally at different places in our code, these warnings result in many false positives. Temporarily, disabling the flag using pragmas is not viable as it is caused by macros that provide an expression. So we could not just fix the macro, but wherever it is used.

Tracked by: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578