### PR TITLE
ci: ubuntu-latest is now Ubuntu 24.04

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -15,7 +15,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential clang qemu qemu-user
+        sudo apt-get install -y build-essential clang qemu-system qemu-user
     - uses: actions/checkout@v2
     - name: Build the Docker image (GCC)
       run: ./tools/ci/build-docker.sh gcc

--- a/third-party/acpica/acpica_ktf.patch
+++ b/third-party/acpica/acpica_ktf.patch
@@ -11,3 +11,13 @@
  #include "aclinux.h"
  
  #elif defined(_APPLE) || defined(__APPLE__)
+--- drivers/acpi/acpica/source/components/namespace/nsaccess.c  2023-06-28 23:38:40.000000000 +0200
+@@ -613,6 +613,8 @@
+ 
+             if (SearchParentFlag == ACPI_NS_NO_UPSEARCH)
+             {
++                /* avoid compiler error when not debugging */
++                (void)NumCarats;
+                 ACPI_DEBUG_PRINT ((ACPI_DB_NAMES,
+                     "Search scope is [%4.4s], path has %u carat(s)\n",
+                     AcpiUtGetNodeName (ThisNode), NumCarats));


### PR DESCRIPTION
Use new package names and prevent compiler errors on unused variable in acpi when not debugging.