### PR TITLE
grub,makefile: Make ISO UEFI bootable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ endif
 GRUB_DIR := grub/boot
 GRUB_FILE := grub-file
 GRUB_MKRESCUE := grub-mkrescue
-GRUB_MODULES := multiboot2 iso9660 serial normal
+GRUB_MODULES := multiboot2 iso9660 serial normal all_video
 ifneq ($(UNITTEST),)
 GRUB_CONFIG := grub/grub-test.cfg
 else

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:latest
 
 # build dependencies
 RUN apt-get update -y
-RUN apt-get install -y build-essential clang make xorriso qemu-utils qemu-system-x86 patch
+RUN apt-get install -y build-essential clang make xorriso mtools qemu-utils qemu-system-x86 patch
 # grub is a bit special in containers
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install grub2 kmod python3
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install grub2 grub-efi-amd64-bin kmod python3
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
1. grub-mkrescue requires mtools and grub-efi-amd64-bin for UEFI boot
2. the grub config assumes all_video is present, so we add it